### PR TITLE
Framework for rendering components in CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,5 +6,8 @@
   },
   "devDependencies": {
     "shadow-cljs": "^2.8.37"
+  },
+  "dependencies": {
+    "chalk": "^2.4.2"
   }
 }

--- a/src/sharetribe/flex_cli/commands/help.cljs
+++ b/src/sharetribe/flex_cli/commands/help.cljs
@@ -1,5 +1,34 @@
-(ns sharetribe.flex-cli.commands.help)
+(ns sharetribe.flex-cli.commands.help
+  (:require [sharetribe.flex-cli.render :as render]))
+
+(defn p [content]
+  [[:line {:format [:underline]} content]])
+
+(defn heading [content]
+  [[:line {:format [:white :bold]} content]])
+
+(defn dt [content]
+  [[heading content]])
+
+(defn dd [content]
+  [[:line "  " content]])
+
+(defn section [title value]
+  [[dt title]
+   [dd value]])
 
 (defn help [opts]
-  (println "TODO")
-  (println "help command, options:" opts))
+  (render/render
+   [[p "CLI to interact with Sharetribe Flex"]
+    [:br]
+    [section
+     "Version"
+     "0.0.1"]
+    [:br]
+    [section
+     "Usage"
+     "$ flex [COMMAND]"]]))
+
+(comment
+  (sharetribe.flex-cli.core/main-dev-str "--help")
+  )

--- a/src/sharetribe/flex_cli/render.cljs
+++ b/src/sharetribe/flex_cli/render.cljs
@@ -1,0 +1,60 @@
+(ns sharetribe.flex-cli.render
+  (:refer-clojure :exclude [eval])
+  (:require [chalk]
+            [clojure.string :as str]))
+
+(defn extract-opts [content]
+  (let [[first & rest :as all] content]
+    (if (map? first)
+      [first rest]
+      [nil all])))
+
+(defn format [format-opts s]
+  (if-let [chalk-builder
+           (when (seq format-opts)
+             (goog.object/getValueByKeys chalk (clj->js format-opts)))]
+    (chalk-builder s)
+    s))
+
+(defn br [_]
+  ["\n"])
+
+(defn line [content]
+  (let [[opts content] (extract-opts content)]
+    [(format (:format opts) (str/join content))
+     "\n"]))
+
+(defn eval-tag
+  "Evaluate a built-in tag"
+  [tag content]
+  (case tag
+    :line (line content)
+    :br (br content)))
+
+;; TODO Can be improved with trampoline
+(declare eval-many)
+
+(defn eval-one
+  "Evaluate a single component. Returns a collection, because evaluating
+  a single component may result in many child components."
+  [comp]
+  (let [[f & xs] comp]
+    (if (keyword? f)
+      (eval-tag f xs)
+      (eval-many (apply f xs)))))
+
+(defn eval-many
+  "Evaluate collection of components. Returns a collection of evaluated
+  components."
+  [comps]
+  (mapcat eval-one comps))
+
+(defn eval
+  "Evaluate components. Returns a string."
+  [comps]
+  (apply str (eval-many comps)))
+
+(defn render
+  "Evaluate and print components."
+  [comps]
+  (print (eval comps)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,12 @@
 # yarn lockfile v1
 
 
+ansi-styles@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  dependencies:
+    color-convert "^1.9.0"
+
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -102,12 +108,30 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
+chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+color-convert@^1.9.0:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  dependencies:
+    color-name "1.1.3"
+
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -202,6 +226,10 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
+escape-string-regexp@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+
 events@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.0.0.tgz#9a0a0dfaf62893d92b875b8f2698ca4114973e88"
@@ -212,6 +240,10 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
+
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
 hash-base@^3.0.0:
   version "3.0.4"
@@ -501,6 +533,12 @@ string_decoder@~1.1.1:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
   dependencies:
     safe-buffer "~5.1.0"
+
+supports-color@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  dependencies:
+    has-flag "^3.0.0"
 
 timers-browserify@^2.0.4:
   version "2.0.10"


### PR DESCRIPTION
On top of #3

*(Please note that while I think this implementation works quite nicely, I still consider this PR a proof-of-concept. Does this make sense to you? Is this the way we want to rendering/printing in CLI?)*

This PR implements a Hiccup/Reagent-like syntax for rendering in CLI and building reusable components.

The syntax is similar to Hiccup/Reagent:

```clj
[my-green-list "Item 1" "Item 2"]
```

...or a "built-in" tag that prints one line:

```clj
[:line "This will print one line"]
```

The built-in `:line` tag supports formatting via Chalk:

```clj
[:line {:format [:bold :red]} "This line will be " "bold " "and red"]
```

The component implementation is same as in Reagent:

```
(defn my-green-list [& items]
    (for [i items]
      [:line {:format [:green]} "* " i]))
```

Please note one difference to Reagent syntax: A Reagent component can return either a single component, i.e. `[:div "My div"]`, or multiple components by wrapping them in a `[:div [comp1] [comp2]` or using `[:<> ...]`. In the CLI implementation, there's no option to return a single component from the component implementation. It needs to be always wrapped in a vector. Thus, a component that returns one header line looks like this:

```clj
(defn heading [content]
  [[:line {:format [:bold :white]} content]])
```

If that feels too cumbersome, it can be changed later so that the evaluation code detects whether the component is returning a single component or many.

This PR also implement a skeleton for the `help` command:

![Screen Shot 2019-05-23 at 11 24 48](https://user-images.githubusercontent.com/429876/58237342-922eb880-7d4d-11e9-980b-c8c625dcc2e6.png)
