### PR TITLE
Improve args handling

### DIFF
--- a/src/sharetribe/flex_cli/core.cljs
+++ b/src/sharetribe/flex_cli/core.cljs
@@ -15,7 +15,7 @@
 
 (defn main* [cli-args done-fn]
   (-> cli-args
-      (parse/parse commands/commands commands/global-opts)
+      (parse/parse commands/commands)
       (commands/handle done-fn)))
 
 (defn main

--- a/src/sharetribe/flex_cli/parse.cljs
+++ b/src/sharetribe/flex_cli/parse.cljs
@@ -8,15 +8,14 @@
 
 
 (defn parse
-  "Given command-line `args`, command spec `cmd` and global options spec
-  `global-opts` returns a map containing id and handler from the
+  "Given command-line `args` and command spec `cmd`
+  returns a map containing id and handler from the
   command spec and parsed options.
 
   Params:
 
   - `args` command-line arguments, coll of strings
   - `cmd` a command spec
-  - `global-opts` global opts spec
 
   The command spec is a recursive tree structure supporting any number
   of subcommand levels.
@@ -27,9 +26,8 @@
    :options {}
   }
   "
-  [args cmd global-opts]
-  (let [with-global-opts (concat (:opts cmd) global-opts)
-        parse-result (tools.cli/parse-opts args with-global-opts :in-order true :strict true)
+  [args cmd]
+  (let [parse-result (tools.cli/parse-opts args (:opts cmd) :in-order true :strict true)
         {:keys [options arguments summary errors]} parse-result]
 
     (cond
@@ -40,7 +38,7 @@
                           :options options}
 
       :else (if-let [sub-cmd (find-sub (:sub-cmds cmd) (first arguments))]
-              (recur (rest arguments) sub-cmd global-opts)
+              (recur (rest arguments) sub-cmd)
               {:error :command-not-found
                :data {:arguments arguments}}))))
 
@@ -48,5 +46,4 @@
 
 (s/fdef parse
   :args (s/cat :args ::args
-               :cmd ::commands/root-cmd
-               :global-opts ::commands/global-opts))
+               :cmd ::commands/root-cmd))

--- a/test/sharetribe/flex_cli/parse_test.cljs
+++ b/test/sharetribe/flex_cli/parse_test.cljs
@@ -7,7 +7,7 @@
              :opts [{:id :version
                      :short-opt "-V"
                      :long-opt "-v"}]}
-        parse-result (parse/parse ["-V"] cmd [])]
+        parse-result (parse/parse ["-V"] cmd)]
     (is (= ::main-handler (:handler parse-result)))
     (is (= {:version true} (:options parse-result)))))
 
@@ -16,8 +16,8 @@
                          :handler ::process
                          :sub-cmds [{:name "list"
                                      :handler ::process-list}]}]}]
-    (is (= ::process (:handler (parse/parse ["process"] cmd []))))
-    (is (= ::process-list (:handler (parse/parse ["process" "list"] cmd []))))))
+    (is (= ::process (:handler (parse/parse ["process"] cmd))))
+    (is (= ::process-list (:handler (parse/parse ["process" "list"] cmd))))))
 
 (deftest subcommands+opts
   (let [cmd {:sub-cmds [{:name "process"
@@ -26,25 +26,9 @@
                                      :opts [{:id :process-name
                                              :long-opt "--process"
                                              :required "PROCESS NAME"}]}]}]}
-        parse-result (parse/parse ["process" "list" "--process=nightly-booking"] cmd [])]
+        parse-result (parse/parse ["process" "list" "--process=nightly-booking"] cmd)]
     (is (= ::process-list (:handler parse-result)))
     (is (= {:process-name "nightly-booking"} (:options parse-result)))))
-
-(deftest subcommands+opts+global-opts
-  (let [global-opts [{:id :marketplace
-                      :long-opt "--marketplace"
-                      :short-opt "-m"
-                      :required "MARKETPLACE"}]
-        cmd {:sub-cmds [{:name "process"
-                         :sub-cmds [{:name "list"
-                                     :handler ::process-list
-                                     :opts [{:id :process-name
-                                             :long-opt "--process"
-                                             :required "PROCESS NAME"}]}]}]}
-        parse-result (parse/parse ["process" "list" "--process=nightly-booking" "-m" "bike-soil"] cmd global-opts)]
-    (is (= ::process-list (:handler parse-result)))
-    (is (= {:process-name "nightly-booking"
-            :marketplace "bike-soil"} (:options parse-result)))))
 
 (deftest params-coercion+validation
   (let [cmd {:opts [{:id :number
@@ -56,39 +40,39 @@
                      :required "NUMBER"
                      :missing "Missing number"}]}]
     (testing "missing"
-      (let [parse-result (parse/parse [""] cmd {})]
+      (let [parse-result (parse/parse [""] cmd)]
         (is (= :parse-error (:error parse-result)))
         (is (= ["Missing number"] (-> parse-result :data :errors)))))
 
     (testing "not a number"
-      (let [parse-result (parse/parse ["--number=abc"] cmd {})]
+      (let [parse-result (parse/parse ["--number=abc"] cmd)]
         (is (= :parse-error (:error parse-result)))
         (is (= ["Failed to validate \"--number abc\": Must be a number between 0 and 1000" "Missing number"]
                (-> parse-result :data :errors)))))
 
     (testing "too big number"
-      (let [parse-result (parse/parse ["--number=12345"] cmd {})]
+      (let [parse-result (parse/parse ["--number=12345"] cmd)]
         (is (= :parse-error (:error parse-result)))
         (is (= ["Failed to validate \"--number 12345\": Must be a number between 0 and 1000" "Missing number"]
                (-> parse-result :data :errors)))))
 
     (testing "success"
-      (let [parse-result (parse/parse ["--number=123"] cmd {})]
+      (let [parse-result (parse/parse ["--number=123"] cmd)]
         (is (= nil (:error parse-result)))
         (is (= nil (-> parse-result :data :errors)))))))
 
 (deftest strict-mode
-  (let [global-opts [{:id :marketplace
-                      :long-opt "--marketplace"
-                      :short-opt "-m"
-                      :required "MARKETPLACE"}]
-        cmd {:sub-cmds [{:name "process"
+  (let [cmd {:sub-cmds [{:name "process"
                          :sub-cmds [{:name "list"
                                      :handler ::process-list
-                                     :opts [{:id :process-name
+                                     :opts [{:id :marketplace
+                                             :long-opt "--marketplace"
+                                             :short-opt "-m"
+                                             :required "MARKETPLACE"}
+                                            {:id :process-name
                                              :long-opt "--process"
                                              :short-opt "-p"
                                              :required "PROCESS NAME"}]}]}]}
-        parse-result (parse/parse ["process" "list" "-m" "-p" "nightly-booking"] cmd global-opts)]
+        parse-result (parse/parse ["process" "list" "-m" "-p" "nightly-booking"] cmd)]
     (is (= :parse-error (:error parse-result)))
     (is (= ["Missing required argument for \"-m MARKETPLACE\""] (-> parse-result :data :errors)))))


### PR DESCRIPTION
This PR improves args handling:

1. Adds some tests for parsing and validation
2. Turn on strict mode
3. Remove global opts from parse namespace and let the caller handle that. This gives us more fine-grained control over the global params.