### PR TITLE
View components

### DIFF
--- a/src/sharetribe/flex_cli/commands/help.cljs
+++ b/src/sharetribe/flex_cli/commands/help.cljs
@@ -27,7 +27,7 @@
   (->> cmd
        list-commands
        (sort-by first)
-       io-util/align-cols
+       view/align-cols
        (map (fn [[cmd desc]]
               [:span cmd "  " desc :line]))))
 
@@ -41,7 +41,7 @@
   (->> opts
        (sort-by (juxt :short-opt :long-opt :desc))
        (map format-opt)
-       (io-util/align-cols)
+       view/align-cols
        (map (fn [[opt+req desc]]
               [:span opt+req "  " desc :line]))))
 

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -140,37 +140,3 @@
    (binding [*print-newline* true
              *print-fn* #(js/process.stdout.write %)]
      (fipp/pprint-document document options))))
-
-(defn transpose
-  ;; https://stackoverflow.com/a/10347404
-  [m]
-  (apply map list m))
-
-(defn right-pad [s length]
-  (str s (apply str (repeat (- length (count s)) " "))))
-
-(defn longest-width
-  "Takes collection of strings `xs` and returns the count of the longest
-  one."
-  [xs]
-  ;; Assumes strings and uses simple count. This could be improved in
-  ;; the future to accept Fipp primitives and correctly
-  ;; count :escaped, :pass, etc.
-  (apply max (map count xs)))
-
-(defn align-cols
-  "Takes 2d collection `rows` and makes the columns equal size.
-
-  Example:
-
-  (align-cols
-   [[\"abc\"\"1\"]
-    [\"d\" \"efghij\"]])
-  =>
-  ((\"abc\" \"1     \")
-   (\"d  \" \"efghij\"))
-  "
-  [rows]
-  (let [cols (transpose rows)
-        col-widths (mapv longest-width cols)]
-    (map #(map right-pad % col-widths) rows)))

--- a/src/sharetribe/flex_cli/view.cljs
+++ b/src/sharetribe/flex_cli/view.cljs
@@ -17,3 +17,37 @@
   ([coll] (join-some "" coll))
   ([sep coll]
    (str/join sep (filter some? coll))))
+
+(defn transpose
+  ;; https://stackoverflow.com/a/10347404
+  [m]
+  (apply map list m))
+
+(defn right-pad [s length]
+  (str s (apply str (repeat (- length (count s)) " "))))
+
+(defn longest-width
+  "Takes collection of strings `xs` and returns the count of the longest
+  one."
+  [xs]
+  ;; Assumes strings and uses simple count. This could be improved in
+  ;; the future to accept Fipp primitives and correctly
+  ;; count :escaped, :pass, etc.
+  (apply max (map count xs)))
+
+(defn align-cols
+  "Takes 2d collection `rows` and makes the columns equal size.
+
+  Example:
+
+  (align-cols
+   [[\"abc\"\"1\"]
+    [\"d\" \"efghij\"]])
+  =>
+  ((\"abc\" \"1     \")
+   (\"d  \" \"efghij\"))
+  "
+  [rows]
+  (let [cols (transpose rows)
+        col-widths (mapv longest-width cols)]
+    (map #(map right-pad % col-widths) rows)))


### PR DESCRIPTION
This PR adds a new namespace for view util functions and view component functions.

Some functions (i.e. col alignment) is moved from io-util namespace to view namespace. I'd say we can keep the io-util namespace and put io functions there (meaning functions that really do io, like read a file or print to stdout) but the view namespace is for utils that are pure data in data out.