### PR TITLE
Improve API error message

### DIFF
--- a/src/sharetribe/flex_cli/cli_info.cljs
+++ b/src/sharetribe/flex_cli/cli_info.cljs
@@ -1,0 +1,4 @@
+(ns sharetribe.flex-cli.cli-info)
+
+(def ^:const bin "flex-cli")
+(def ^:const version "0.0.1")

--- a/src/sharetribe/flex_cli/commands/help.cljs
+++ b/src/sharetribe/flex_cli/commands/help.cljs
@@ -1,12 +1,10 @@
 (ns sharetribe.flex-cli.commands.help
   (:require [sharetribe.flex-cli.io-util :as io-util]
+            [sharetribe.flex-cli.cli-info :as cli-info]
             [sharetribe.flex-cli.command-util :as command-util]
             [sharetribe.flex-cli.view :as view]
             [chalk]
             [clojure.string :as str]))
-
-(def ^:const bin "flex-cli")
-(def ^:const version "0.0.1")
 
 (defn list-commands
   "Recursively traverse through the list of commands and return a list
@@ -74,7 +72,7 @@
   "Usage section"
   ([] (usage ["[COMMAND]"]))
   ([args]
-   [:span "$ " (str/join " " (concat [bin] args))]))
+   [:span "$ " (str/join " " (concat [cli-info/bin] args))]))
 
 ;; Command handlers
 
@@ -103,7 +101,7 @@
 
    (section
     "VERSION"
-    version)
+    cli-info/version)
 
    (section
     "USAGE"
@@ -114,7 +112,7 @@
     (command-help (:sub-cmds cmd)))
 
    [:span "Subcommand help:"]
-   [:nest "$ " bin " help [COMMAND]"]))
+   [:nest "$ " cli-info/bin " help [COMMAND]"]))
 
 (defn help [opts ctx]
   (let [{:keys [commands arguments]} ctx]

--- a/src/sharetribe/flex_cli/core.cljs
+++ b/src/sharetribe/flex_cli/core.cljs
@@ -5,7 +5,8 @@
             [sharetribe.flex-cli.async-util :refer [<?]]
             [sharetribe.flex-cli.command-defs :as command-defs]
             [sharetribe.flex-cli.command-exec :as command-exec]
-            [sharetribe.flex-cli.exception :as exception]))
+            [sharetribe.flex-cli.exception :as exception]
+            [sharetribe.flex-cli.io-util :as io-util]))
 
 (defn done [status]
   (when-let [status (:exit-status status)]
@@ -18,8 +19,7 @@
     (println "[dev] Exit status:" status)))
 
 (defn print-error [e]
-  (binding [*print-fn* *print-err-fn*]
-    (println (exception/format-msg e))))
+  (io-util/ppd-err (exception/format-msg e)))
 
 (defn error [e done-fn]
   (print-error e)

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -191,6 +191,16 @@
              *print-fn* #(js/process.stdout.write %)]
      (fipp/pprint-document document options))))
 
+(defn ppd-err
+  "Pretty print Fipp document.
+
+  Output to stderr"
+  ([document] (ppd-err document {}))
+  ([document options]
+   (binding [*print-newline* true
+             *print-fn* #(js/process.stderr.write %)]
+     (fipp/pprint-document document options))))
+
 (defn prompt
   "Thin wrapper around inquirer.
 


### PR DESCRIPTION
Improve API error messages and formatting.

Biggest improvement is catching 401 error and rendering helpful error message with information about the marketplace and API key.

This PR also introduces a new format for error messages (small red arrow in front of each line). If we want we can start using this format for other errors as well.

Screenshot

<img width="731" alt="Screen Shot 2019-08-14 at 22 20 57" src="https://user-images.githubusercontent.com/429876/63050056-cea02980-bee2-11e9-9443-dc530824f7c6.png">
