### PR TITLE
Add process delete-alias command

### DIFF
--- a/src/sharetribe/flex_cli/commands/process.cljs
+++ b/src/sharetribe/flex_cli/commands/process.cljs
@@ -6,6 +6,7 @@
             [sharetribe.flex-cli.commands.process.push :as process.push]
             [sharetribe.flex-cli.commands.process.create-alias :as process.create-alias]
             [sharetribe.flex-cli.commands.process.update-alias :as process.update-alias]
+            [sharetribe.flex-cli.commands.process.delete-alias :as process.delete-alias]
             [sharetribe.tempelhof.tx-process :as tx-process]))
 
 (declare describe-process)
@@ -43,7 +44,8 @@
                      process.pull/cmd
                      process.push/cmd
                      process.create-alias/cmd
-                     process.update-alias/cmd]})
+                     process.update-alias/cmd
+                     process.delete-alias/cmd]})
 
 (defn- load-tx-process-from-path
   "Load process from given path (directory). Encapsulates the idea of

--- a/src/sharetribe/flex_cli/commands/process/delete_alias.cljs
+++ b/src/sharetribe/flex_cli/commands/process/delete_alias.cljs
@@ -1,0 +1,34 @@
+(ns sharetribe.flex-cli.commands.process.delete-alias
+  (:require [clojure.core.async :as async :refer [go <!]]
+            [sharetribe.flex-cli.async-util :refer [<? go-try]]
+            [sharetribe.flex-cli.api.client :refer [do-post]]
+            [sharetribe.flex-cli.io-util :as io-util]))
+
+(declare delete-alias)
+
+(def cmd {:name "delete-alias"
+          :handler #'delete-alias
+          :desc "delete an existing alias"
+          :opts [{:id :process-name
+                  :long-opt "--process"
+                  :required "PROCESS_NAME"
+                  :missing "--process is required"
+                  :desc "process name, see process list for available names"}
+                 {:id :alias
+                  :long-opt "--alias"
+                  :required "ALIAS"
+                  :missing "--alias is required"
+                  :desc "alias name, e.g. release-1"}]})
+
+(defn delete-alias [params ctx]
+  (go-try
+   (let [{:keys [api-client marketplace]} ctx
+         {:keys [process-name version alias]} params
+         query-params {:marketplace marketplace}
+         body-params {:name (keyword process-name)
+                      :alias (keyword alias)}
+         res (<? (do-post api-client "/aliases/delete-alias" query-params body-params))]
+     (io-util/ppd [:span
+                   "Alias "
+                   (-> res :data :processAlias/alias io-util/namespaced-str)
+                   " successfully deleted."]))))


### PR DESCRIPTION
This PR adds a new command `process delete-alias` for deleting process aliases.

## Spec

> - `flex process delete-alias --process <process-name> --alias <process-alias>` - Delete a process alias to prevent access to a deprecated process version.

## CLI

<img width="439" alt="Screen Shot 2019-09-03 at 14 29 29" src="https://user-images.githubusercontent.com/53923/64169827-4795ff80-ce57-11e9-9d01-272fcc1354d2.png">

## Initial state

![Screen Shot 2019-09-03 at 14 26 09](https://user-images.githubusercontent.com/53923/64169840-4f55a400-ce57-11e9-9010-402894298471.png)

## With new alias created

![Screen Shot 2019-09-03 at 14 26 46](https://user-images.githubusercontent.com/53923/64169853-567cb200-ce57-11e9-8659-49d7a4aba274.png)

## After deleting the new alias

![Screen Shot 2019-09-03 at 14 27 12](https://user-images.githubusercontent.com/53923/64169861-5c729300-ce57-11e9-9cfe-b2db70798542.png)
