### PR TITLE
Process list versions and aliases for a specific process

### DIFF
--- a/src/sharetribe/flex_cli/commands/process/list.cljs
+++ b/src/sharetribe/flex_cli/commands/process/list.cljs
@@ -1,5 +1,6 @@
 (ns sharetribe.flex-cli.commands.process.list
-  (:require [clojure.core.async :as async :refer [go <!]]
+  (:require [clojure.string :as str]
+            [clojure.core.async :as async :refer [go <!]]
             [sharetribe.flex-cli.api.client :refer [do-get]]
             [sharetribe.flex-cli.async-util :refer [<? go-try]]
             [sharetribe.flex-cli.io-util :as io-util]))
@@ -8,19 +9,36 @@
 
 (def cmd {:name "list"
           :handler #'list-processes
-          :desc "list all transaction processes"})
+          :desc "list all transaction processes"
+          :opts [{:id :process-name
+                  :long-opt "--process"
+                  :required "PROCESS_NAME"}]})
 
-(defn list-processes [_ ctx]
+(defn list-all-processes [api-client marketplace]
   (go-try
-    (let [{:keys [api-client marketplace]} ctx
-          res (<? (do-get api-client "/processes/query" {:marketplace marketplace}))
-          process-names (map (fn [{:process/keys [name version]}]
-                               {:name (io-util/namespaced-str name)
-                                :latest-version version})
-                             (:data res))]
+   (let [res (<? (do-get api-client "/processes/query" {:marketplace marketplace}))
+         process-names (map (fn [{:process/keys [name version]}]
+                              {:name (io-util/namespaced-str name)
+                               :latest-version version})
+                            (:data res))]
 
-      (io-util/print-table process-names))))
+     (io-util/print-table process-names))))
 
-(comment
-  (sharetribe.flex-cli.core/main-dev-str "process list --marketplace=bike-soil")
-  )
+(defn list-process-versions [api-client marketplace process-name]
+  (go-try
+   (let [res (<? (do-get api-client "/processes/query-versions" {:marketplace marketplace
+                                                                 :name process-name}))
+         versions (map (fn [{:process/keys [version createdAt aliases transactionCount]}]
+                         {:created (io-util/format-date-and-time createdAt)
+                          :version version
+                          :aliases (str/join ", " (map io-util/namespaced-str aliases))
+                          :transactions transactionCount})
+                       (:data res))]
+     (io-util/print-table versions))))
+
+(defn list-processes [params ctx]
+  (let [{:keys [api-client marketplace]} ctx
+        {:keys [process-name]} params]
+    (if process-name
+      (list-process-versions api-client marketplace process-name)
+      (list-all-processes api-client marketplace))))

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -176,6 +176,28 @@
 ;;   (when inst
 ;;     (unparse (formatter "yyyy-MM-dd HH:mm") (to-date-time inst))))
 
+(defn format-date-and-time
+  "Format given inst as a local date time
+
+  Example:
+
+  > (format-date-and-time (js/Date.))
+  \"2019-09-06 9:22:47 AM\"
+  "
+  [inst]
+  (when inst
+    (let [pad (fn [n]
+                (if (< n 10)
+                  (str "0" n)
+                  (str n)))]
+      (str (.getFullYear inst)
+           "-"
+           (pad (inc (.getMonth inst)))
+           "-"
+           (pad (.getDate inst))
+           " "
+           (.toLocaleTimeString inst "en-US")))))
+
 (defn format-code [code]
   (if code
     (.green chalk (with-out-str (pprint code)))


### PR DESCRIPTION
This PR adds the `--process` option for the `process list` command to list versions and aliases of the given process.

## CLI

<img width="634" alt="Screen Shot 2019-09-06 at 10 27 09" src="https://user-images.githubusercontent.com/53923/64413184-afd42380-d099-11e9-9349-905a280c6200.png">

## Console

![Screen Shot 2019-09-06 at 10 27 02](https://user-images.githubusercontent.com/53923/64409221-20c30d80-d091-11e9-83ff-5e7a0e5c82e7.png)
