### PR TITLE
Validate that notification templates exist on disk for process push

### DIFF
--- a/src/sharetribe/flex_cli/commands/process/push.cljs
+++ b/src/sharetribe/flex_cli/commands/process/push.cljs
@@ -85,7 +85,7 @@
         template-names (set (map :name templates))
         extra-tmpls (set/difference template-names process-tmpl-names)
         missing-templates (remove (fn [n]
-                                    (template-names (:template n)))
+                                    (contains? template-names (:template n)))
                                   (:notifications tx-process))]
     (doseq [t extra-tmpls]
       (io-util/ppd-err [:span


### PR DESCRIPTION
This PR adds a template validation step before process push. Missing templates yield an error, and extra templates yield a warning.

<img width="928" alt="Screen Shot 2019-09-11 at 10 10 26" src="https://user-images.githubusercontent.com/53923/64675708-85f57500-d47c-11e9-81c0-35e1741805f6.png">
