### PR TITLE
Print out part info for template validation errors

### DIFF
--- a/src/sharetribe/flex_cli/commands/process/push.cljs
+++ b/src/sharetribe/flex_cli/commands/process/push.cljs
@@ -24,11 +24,12 @@
     (str "\n" error-arrow " " header msg "\n")))
 
 (defn template-error-report [total index error]
-  (let [{:keys [template-name reason evidence line column]} error]
+  (let [{:keys [template-name reason evidence line column template-part]} error]
     (error-report
      total
      index
-     {:msg (str "Error in template " (.bold chalk (name template-name))
+     {:msg (str "Error in " (.bold chalk (name template-name))
+                " template " (name template-part)
                 ". Reason: " reason
                 "\n\n" evidence)
       :loc {:row line


### PR DESCRIPTION
This PR adds part info (html file or subject file) to the template validation errors.

<img width="578" alt="Screen Shot 2019-09-11 at 11 06 42" src="https://user-images.githubusercontent.com/53923/64679517-8bef5400-d484-11e9-999f-c20b76a31618.png">

<img width="619" alt="Screen Shot 2019-09-11 at 11 07 00" src="https://user-images.githubusercontent.com/53923/64679526-901b7180-d484-11e9-9826-dbcc5324c8d5.png">
