### PR TITLE
CLI info in HTTP headers

### DIFF
--- a/src/sharetribe/flex_cli/api/client.cljs
+++ b/src/sharetribe/flex_cli/api/client.cljs
@@ -106,7 +106,7 @@
       :method :get
       :params query
       :headers {"Authorization" (str "Apikey " (::api-key client))
-                "User-agent" user-agent}
+                "User-Agent" user-agent}
       :handler (fn [[ok? response]]
                  (put! c
                        (if ok?
@@ -127,7 +127,7 @@
       :url-params query
       :params body
       :headers {"Authorization" (str "Apikey " (::api-key client))
-                "User-agent" user-agent}
+                "User-Agent" user-agent}
       :handler (fn [[ok? response]]
                  (put! c
                        (if ok?


### PR DESCRIPTION
This PR adds CLI version and platform info to the user agent header.

Why user agent? According to [User-Agent docs in MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent), it seems the appropriate place to send such information:

> The User-Agent request header contains a characteristic string that allows the network protocol peers to identify the application type, operating system, software vendor or software version of the requesting software user agent.

I also expect that third party tooling like Sentry and Loggly already record the user agent, so we don't have to do any extra work for recording custom HTTP headers.

**User-Agent before:** `node-XMLHttpRequest`

**User-Agent after:** `flex-cli/0.4.0 (darwin x64; Node.js v12.10.0)`