### PR TITLE
Add stripe update-version command

### DIFF
--- a/src/sharetribe/flex_cli/args_parse.cljs
+++ b/src/sharetribe/flex_cli/args_parse.cljs
@@ -48,10 +48,12 @@
 
     (if (or (empty? arguments)
             (:catch-all? cmd))
-      {:handler (:handler cmd)
-       :no-api-key? (:no-api-key? cmd)
-       :options options
-       :arguments arguments}
+      (if-let [handler (:handler cmd)]
+        {:handler handler
+         :no-api-key? (:no-api-key? cmd)
+         :options options
+         :arguments arguments}
+        (exception/throw! :command/not-found {:arguments [(:name cmd)]}))
       (if-let [sub-cmd (find-sub (:sub-cmds cmd) (first arguments))]
         (recur (rest arguments) sub-cmd)
         (exception/throw! :command/not-found {:arguments arguments})))))

--- a/src/sharetribe/flex_cli/command_defs.cljs
+++ b/src/sharetribe/flex_cli/command_defs.cljs
@@ -4,6 +4,7 @@
             [sharetribe.flex-cli.commands.help :as help]
             [sharetribe.flex-cli.commands.main :as main]
             [sharetribe.flex-cli.commands.process :as process]
+            [sharetribe.flex-cli.commands.stripe :as stripe]
             [sharetribe.flex-cli.commands.version :as version]))
 
 (def marketplace-opt
@@ -46,6 +47,7 @@
      :no-api-key? true
      :no-marketplace? true
      :handler logout/logout}
+    stripe/cmd
     process/cmd]})
 
 (defn- with-marketplace-opt [cmd]

--- a/src/sharetribe/flex_cli/commands/help.cljs
+++ b/src/sharetribe/flex_cli/commands/help.cljs
@@ -15,9 +15,9 @@
    (->> cmds
         (remove :hidden?)
         (mapcat
-         (fn [{:keys [name desc sub-cmds]}]
+         (fn [{:keys [name desc sub-cmds handler]}]
            (concat
-            [[(str/join " " (conj parent-cmds name)) (or desc "")]]
+            (when handler [[(str/join " " (conj parent-cmds name)) (or desc "")]])
             (when sub-cmds
               (list-commands sub-cmds (conj parent-cmds name)))))))))
 

--- a/src/sharetribe/flex_cli/commands/stripe.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe.cljs
@@ -1,0 +1,8 @@
+(ns sharetribe.flex-cli.commands.stripe
+  (:require [sharetribe.flex-cli.commands.stripe.update-version :as stripe.update-version]))
+
+(def cmd {:name "stripe"
+          ;; Set to true, because handler is missing and we want Command not found error.
+          :no-marketplace? true
+          :sub-cmds [stripe.update-version/cmd]})
+

--- a/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
@@ -8,13 +8,15 @@
 
 (declare update-version)
 
+(def ^:const supported-versions #{"2019-02-19" "2019-09-09"})
+
 (def cmd {:name "update-version"
           :handler #'update-version
           :desc "Update Stripe API version in use."
           :opts [{:id :version
                   :long-opt "--version"
                   :required "VERSION"
-                  :desc "Stripe API version to update to. One of 2019-02-19 or 2019-09-09."}
+                  :desc (str "Stripe API version to update to. One of: " (str/join ", " supported-versions) ".")}
                  {:id :force
                   :long-opt "--force"
                   :short-opt "-f"
@@ -24,7 +26,7 @@
   (when-not (#{"2019-02-19" "2019-09-09"} version)
     (exception/throw! :command/invalid-args
                       {:command :update-version
-                       :errors ["--version should be one of 2019-02-19 or 2019-09-09. Was: " version]})))
+                       :errors [(str "--version should be one of: " (str/join ", " supported-versions) ". Was " version ".")]})))
 
 (defn confirm! [force version]
   (let [confirm (or force
@@ -46,7 +48,7 @@
 
          version (or version
                      (:version (<! (io-util/prompt [{:name :version
-                                                     :choices ["2019-09-09" "2019-02-19"]
+                                                     :choices supported-versions
                                                      :type :list
                                                      :message "Stripe API version"}]))))
 

--- a/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
@@ -1,0 +1,66 @@
+(ns sharetribe.flex-cli.commands.stripe.update-version
+  (:require [clojure.string :as str]
+            [clojure.core.async :as async :refer [<!]]
+            [sharetribe.flex-cli.api.client :as api.client :refer [do-post]]
+            [sharetribe.flex-cli.async-util :refer [<? go-try]]
+            [sharetribe.flex-cli.io-util :as io-util]
+            [sharetribe.flex-cli.exception :as exception]))
+
+(declare update-version)
+
+(def cmd {:name "update-version"
+          :handler #'update-version
+          :desc "Update Stripe API version in use."
+          :opts [{:id :version
+                  :long-opt "--version"
+                  :required "VERSION"
+                  :desc "Stripe API version to update to. One of 2019-02-19 or 2019-09-09."}
+                 {:id :force
+                  :long-opt "--force"
+                  :short-opt "-f"
+                  :desc "Force Stripe API version update without confirmation."}]})
+
+(defn ensure-valid-version! [version]
+  (when-not (#{"2019-02-19" "2019-09-09"} version)
+    (exception/throw! :command/invalid-args
+                      {:command :update-version
+                       :errors ["--version should be one of 2019-02-19 or 2019-09-09. Was: " version]})))
+
+(defn confirm! [force version]
+  (let [confirm (or force
+                    (:confirm (<! (io-util/prompt [{:name :confirm
+                                                    :type :confirm
+                                                    :default false
+                                                    :message (str "Updating Stripe API version to " version ".\n"
+                                                                  "Make sure you are handling Capabilities (https://stripe.com/docs/connect/capabilities-overview)\n"
+                                                                  "and identity verification (https://stripe.com/docs/connect/identity-verification)\n"
+                                                                  "in your front end as specified by your new API version.\n\n"
+                                                                  "Confirm?")}]))))]
+    (when-not confirm
+      (exception/throw! :command/not-confirmed "Stripe API version update not confirmed. Exiting.")) ))
+
+(defn update-version [params ctx]
+  (go-try
+   (let [{:keys [api-client marketplace]} ctx
+         {:keys [version force]} params
+
+         version (or version
+                     (:version (<! (io-util/prompt [{:name :version
+                                                     :choices ["2019-09-09" "2019-02-19"]
+                                                     :type :list
+                                                     :message "Stripe API version"}]))))
+
+         _ (ensure-valid-version! version)
+         _ (confirm! force version)
+
+         query-params {:marketplace marketplace}
+         body-params {:version version}
+
+         res (try
+               (<? (do-post api-client "/stripe/update-version" query-params body-params))
+               (catch js/Error e
+                 (throw
+                  (api.client/retype-ex e :stripe/update-api-version-failed))))]
+
+     (io-util/ppd (str "Stripe API version successfully changed to " (-> res :data))))))
+

--- a/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
@@ -51,7 +51,7 @@
                                                      :message (str "Updating Stripe API version to " version ".\n"
                                                                    "Make sure you are handling Capabilities (https://stripe.com/docs/connect/capabilities-overview)\n"
                                                                    "and identity verification (https://stripe.com/docs/connect/identity-verification)\n"
-                                                                   "in your front end as specified by your new API version.\n\n"
+                                                                   "in your frontend as specified by your new API version.\n\n"
                                                                    "Confirm?")}]))))
          _ (ensure-confirmed! confirm)
 

--- a/test/sharetribe/flex_cli/parse_test.cljs
+++ b/test/sharetribe/flex_cli/parse_test.cljs
@@ -31,7 +31,8 @@
     (is (= {:process-name "nightly-booking"} (:options parse-result)))))
 
 (deftest params-coercion+validation
-  (let [cmd {:opts [{:id :number
+  (let [cmd {:handler ::process-list
+             :opts [{:id :number
                      :short-opt "-n"
                      :long-opt "--number"
                      :parse-fn #(js/parseInt %)


### PR DESCRIPTION
- Adds basic subcommand for updating Stripe api version
  - Command line options for updating version and forcing update without confirmation
  - If above not provided, uses inquirer to update version interactively
- Handles confirmation of API version update
- Throw command not found on nil handler
- Don't show nil handler commands in help

**Help:**
![image](https://user-images.githubusercontent.com/230815/67461993-50c96e80-f647-11e9-9ab9-08d7ebcf636d.png)

**Help for subcommand:**
![image](https://user-images.githubusercontent.com/230815/67462015-5fb02100-f647-11e9-9b70-52bef812297a.png)

**Version selection:**
![image](https://user-images.githubusercontent.com/230815/67462187-bcabd700-f647-11e9-9d9d-7b7ce462da7b.png)


**Confirm dialog:**
![image](https://user-images.githubusercontent.com/230815/67462056-78203b80-f647-11e9-9fec-f7098da95bc1.png)

