### PR TITLE
Validate timepoints

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
   org.clojure/core.async {:mvn/version "0.4.500"}
   cljs-node-io {:mvn/version "1.1.2"}
   phrase {:mvn/version "0.3-alpha4"}
-  borkdude/edamame {:mvn/version "0.0.4"}
+  borkdude/edamame {:mvn/version "0.0.7"}
   fipp {:mvn/version "0.6.18"}
   aysylu/loom {:mvn/version "1.0.2"}
   thheller/shadow-cljs {:mvn/version "2.8.58"}

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -187,6 +187,38 @@
   {:msg "Invalid time expression."
    :loc (find-first-loc tx-process problem)})
 
+(defphraser tempelhof.spec/valid-transitions-in-transition-timepoints?
+  [{:keys [tx-process]} _]
+  (let [invalid-timepoints (tempelhof.spec/invalid-transitions-in-transition-timepoints tx-process)]
+    (map (fn [n]
+           {:msg (str "Invalid transition " (:ref n) " used in time expression of transition " (:source n) " :at")
+            :loc (location (:at n))})
+         invalid-timepoints)))
+
+(defphraser tempelhof.spec/valid-states-in-transition-timepoints?
+  [{:keys [tx-process]} _]
+  (let [invalid-timepoints (tempelhof.spec/invalid-states-in-transition-timepoints tx-process)]
+    (map (fn [n]
+           {:msg (str "Invalid state " (:ref n) " used in time expression of transition " (:source n) " :at")
+            :loc (location (:at n))})
+         invalid-timepoints)))
+
+(defphraser tempelhof.spec/valid-transitions-in-notification-timepoints?
+  [{:keys [tx-process]} _]
+  (let [invalid-timepoints (tempelhof.spec/invalid-transitions-in-notification-timepoints tx-process)]
+    (map (fn [n]
+           {:msg (str "Invalid transition " (:ref n) " used in time expression of notification " (:source n) " :at")
+            :loc (location (:at n))})
+         invalid-timepoints)))
+
+(defphraser tempelhof.spec/valid-states-in-notification-timepoints?
+  [{:keys [tx-process]} _]
+  (let [invalid-timepoints (tempelhof.spec/invalid-states-in-notification-timepoints tx-process)]
+    (map (fn [n]
+           {:msg (str "Invalid state " (:ref n) " used in time expression of notification " (:source n) " :at")
+            :loc (location (:at n))})
+         invalid-timepoints)))
+
 ;; Not sure if this is a good idea?... But if it is it should be moved
 ;; to a util lib.
 (def error-arrow (.bold.red chalk "\u203A"))

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -191,7 +191,7 @@
   [{:keys [tx-process]} _]
   (let [invalid-timepoints (tempelhof.spec/invalid-transitions-in-transition-timepoints tx-process)]
     (map (fn [n]
-           {:msg (str "Invalid transition " (:ref n) " used in time expression of transition " (:source n) " :at")
+           {:msg (str "Unknown transition " (:ref n) " used in time expression of transition " (:source n) " :at")
             :loc (location (:at n))})
          invalid-timepoints)))
 
@@ -199,7 +199,7 @@
   [{:keys [tx-process]} _]
   (let [invalid-timepoints (tempelhof.spec/invalid-states-in-transition-timepoints tx-process)]
     (map (fn [n]
-           {:msg (str "Invalid state " (:ref n) " used in time expression of transition " (:source n) " :at")
+           {:msg (str "Unknown state " (:ref n) " used in time expression of transition " (:source n) " :at")
             :loc (location (:at n))})
          invalid-timepoints)))
 
@@ -207,7 +207,7 @@
   [{:keys [tx-process]} _]
   (let [invalid-timepoints (tempelhof.spec/invalid-transitions-in-notification-timepoints tx-process)]
     (map (fn [n]
-           {:msg (str "Invalid transition " (:ref n) " used in time expression of notification " (:source n) " :at")
+           {:msg (str "Unknown transition " (:ref n) " used in time expression of notification " (:source n) " :at")
             :loc (location (:at n))})
          invalid-timepoints)))
 
@@ -215,7 +215,7 @@
   [{:keys [tx-process]} _]
   (let [invalid-timepoints (tempelhof.spec/invalid-states-in-notification-timepoints tx-process)]
     (map (fn [n]
-           {:msg (str "Invalid state " (:ref n) " used in time expression of notification " (:source n) " :at")
+           {:msg (str "Unknown state " (:ref n) " used in time expression of notification " (:source n) " :at")
             :loc (location (:at n))})
          invalid-timepoints)))
 


### PR DESCRIPTION
Validates that the timepoints refer to a valid transition and state names.

Also, updated Edamame. Old version failed to parse e.g. this: `[1 2 #_3]`

The code contains some amount of repetition, but I decided to keep it that way to keep things simple. If you have ideas where repetition could be reduced without adding too much complexity, let me know.

Screenshot:

<img width="768" alt="Screen Shot 2019-10-24 at 10 42 41" src="https://user-images.githubusercontent.com/429876/67463928-0a760e80-f64b-11e9-84f9-ef26750cbee0.png">
