### PR TITLE
Notifications preview command

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "form-data": "^2.5.1",
     "inquirer": "^6.2.2",
     "mkdirp": "^0.5.1",
+    "open": "^7.0.0",
     "rimraf": "^3.0.0",
+    "tmp": "^0.1.0",
     "xmlhttprequest": "^1.8.0"
   }
 }

--- a/src/sharetribe/flex_cli/command_defs.cljs
+++ b/src/sharetribe/flex_cli/command_defs.cljs
@@ -6,7 +6,8 @@
             [sharetribe.flex-cli.commands.process :as process]
             [sharetribe.flex-cli.commands.search-schema :as search-schema]
             [sharetribe.flex-cli.commands.stripe :as stripe]
-            [sharetribe.flex-cli.commands.version :as version]))
+            [sharetribe.flex-cli.commands.version :as version]
+            [sharetribe.flex-cli.commands.notifications :as notifications]))
 
 (def marketplace-opt
   {:id :marketplace
@@ -50,7 +51,8 @@
      :handler logout/logout}
     stripe/cmd
     process/cmd
-    search-schema/cmd]})
+    search-schema/cmd
+    notifications/cmd]})
 
 (defn- with-marketplace-opt [cmd]
   (if (:no-marketplace? cmd)

--- a/src/sharetribe/flex_cli/commands/notifications.cljs
+++ b/src/sharetribe/flex_cli/commands/notifications.cljs
@@ -1,0 +1,5 @@
+(ns sharetribe.flex-cli.commands.notifications
+  (:require [sharetribe.flex-cli.commands.notifications.preview :as notifications.preview]))
+
+(def cmd {:name "notifications"
+          :sub-cmds [notifications.preview/cmd]})

--- a/src/sharetribe/flex_cli/commands/notifications/preview.cljs
+++ b/src/sharetribe/flex_cli/commands/notifications/preview.cljs
@@ -1,0 +1,72 @@
+(ns sharetribe.flex-cli.commands.notifications.preview
+  (:require [clojure.string :as str]
+            [clojure.core.async :as async :refer [go <!]]
+            [sharetribe.flex-cli.async-util :refer [<? go-try]]
+            [sharetribe.flex-cli.io-util :as io-util]
+            [sharetribe.flex-cli.process-util :as process-util]
+            [sharetribe.flex-cli.api.client :as api.client :refer [do-post]]
+            [sharetribe.flex-cli.exception :as exception]
+            [chalk]
+            [tmp]
+            [open]))
+
+(declare preview)
+
+(def cmd {:name "preview"
+          :handler #'preview
+          :desc "render a preview of an email template"
+          :opts [{:id :template
+                  :long-opt "--template"
+                  :desc "path to a template directory"
+                  :required "TEMPLATE_DIR"
+                  :missing "--template is required"}
+                 {:id :context
+                  :long-opt "--context"
+                  :desc "path to an email rendering context JSON file"
+                  :required "CONTEXT_FILE_PATH"}]})
+
+(defn bold [str]
+  (.bold chalk str))
+
+(defmethod exception/format-exception :notifications.preview/api-call-failed [_ _ data]
+  (case (:code (api.client/api-error data))
+    :invalid-template (process-util/format-invalid-template-error data)
+    (api.client/default-error-format data)))
+
+(defn open-tmp-file! [{:keys [subject html]}]
+  (let [file (tmp/fileSync (clj->js {:keep true
+                                     :prefix "preview-"
+                                     :postfix ".html"}))
+
+        ;; Inject subject as a <title> tag to the HTML
+        head (str "<head><title>" subject "</title></head>")
+        content (str/replace html #"^<html>" (str "<html>" head))]
+    (io-util/save-file (.-name file) content)
+    (println "Opening preview HTML in" (.-name file))
+    (open (.-name file))))
+
+(defn preview [params ctx]
+  (go-try
+   (let [{:keys [api-client marketplace]} ctx
+         {:keys [template context]} params
+         tmpl (io-util/read-template template)
+         body (cond-> {:template tmpl}
+                context (assoc :template-context (io-util/load-file context)))
+         res (try
+               (<? (do-post api-client
+                            "/notifications/preview"
+                            {:marketplace marketplace}
+                            body))
+               (catch js/Error e
+                 (throw
+                  (api.client/retype-ex e :notifications.preview/api-call-failed))))
+         {:keys [subject html text] :as tmpl} (:data res)]
+     (println (str (bold "Template: ") (name (:name tmpl))
+                   (bold "\nSubject: ") subject
+                   (bold "\nText:\n") text
+                   "\n---"))
+     (open-tmp-file! {:subject subject :html html}))))
+
+(comment
+  (sharetribe.flex-cli.core/main-dev-str "notifications preview -m bike-soil --template test-process/templates/booking-request-accepted --context test-process/sample-context.json")
+  )

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -20,6 +20,8 @@
 
 (def ^:const process-filename "process.edn")
 (def ^:const templates-dir "templates")
+(def ^:const template-subject-suffix "-subject.txt")
+(def ^:const template-html-suffix "-html.html")
 
 (defmethod exception/format-exception :io/file-not-found [_ _ {:keys [path]}]
   (str "File not found: " path))
@@ -94,10 +96,16 @@
   (join (templates-path path) template-name))
 
 (defn html-file-path [path template-name]
-  (join (template-path path template-name) (str template-name "-html.html")))
+  (join (template-path path template-name) (str template-name template-html-suffix)))
 
 (defn subject-file-path [path template-name]
-  (join (template-path path template-name) (str template-name "-subject.txt")))
+  (join (template-path path template-name) (str template-name template-subject-suffix)))
+
+(defn read-template [tmpl-path]
+  (let [name (-> tmpl-path fs/path.parse .-name)]
+    {:name (keyword name)
+     :html (load-file (join tmpl-path (str name template-html-suffix)))
+     :subject (load-file (join tmpl-path (str name template-subject-suffix)))}))
 
 (defn read-templates [path]
   (let [tmpls-path (templates-path path)]

--- a/src/sharetribe/flex_cli/process_util.cljs
+++ b/src/sharetribe/flex_cli/process_util.cljs
@@ -44,6 +44,10 @@
       :line]
      (map-indexed (partial template-error-report total-errors) errors))))
 
+(defn format-invalid-template-error [data]
+  (let [error (-> (api.client/api-error data) :details :render-error)]
+    (template-error-report 1 0 error)))
+
 (defn- format-process-exists-error [data]
   [:span error-arrow
    " Process already exists: "

--- a/test-process/process.edn
+++ b/test-process/process.edn
@@ -1,176 +1,175 @@
-;; Preauth with nightly booking transaction process:
-;; https://github.com/sharetribe/sharetribe-custom/blob/master/resources/process_definitions/preauth-nightly-booking.edn
-{:format :v3
-
- :transitions [{:name :transition/enquire
-                :actor :actor.role/customer
-                :actions []
-                :to :state/enquiry}
-
-               {:name :transition/request
-                :actor :actor.role/customer
-                :actions [{:name :action/create-booking
-                           :config {:observe-availability? true}}
-                          {:name :action/calculate-tx-nightly-total-price}
-                          {:name :action/calculate-tx-provider-commission
-                           :config {:commission 0.1M}}
-                          {:name :action/stripe-create-charge}]
-                :to :state/preauthorized}
-
-               {:name :transition/request-after-enquiry
-                :actor :actor.role/customer
-                :actions [{:name :action/create-booking
-                           :config {:observe-availability? true}}
-                          {:name :action/calculate-tx-nightly-total-price}
-                          {:name :action/calculate-tx-provider-commission
-                           :config {:commission 0.1M}}
-                          {:name :action/stripe-create-charge}]
-                :from :state/enquiry
-                :to :state/preauthorized}
-
-               {:name :transition/accept
-                :actor :actor.role/provider
-                :actions [{:name :action/accept-booking}
-                          {:name :action/stripe-capture-charge}]
-                :from :state/preauthorized
-                :to :state/accepted}
-
-               {:name :transition/decline
-                :actor :actor.role/provider
-                :actions [{:name :action/decline-booking}
-                          {:name :action/calculate-full-refund}
-                          {:name :action/stripe-refund-charge}]
-                :from :state/preauthorized
-                :to :state/declined}
-
-               {:name :transition/expire
-                :at {:fn/min [{:fn/plus [{:fn/timepoint [:time/first-entered-state :state/preauthorized]}
-                                         {:fn/period ["P6D"]}]}
-                              {:fn/plus [{:fn/timepoint [:time/booking-end]}
-                                         {:fn/period ["P1D"]}]}]}
-                :actions [{:name :action/decline-booking}
-                          {:name :action/calculate-full-refund}
-                          {:name :action/stripe-refund-charge}]
-                :from :state/preauthorized
-                :to :state/declined}
-
-               {:name :transition/complete
-                :at {:fn/timepoint [:time/booking-end]}
-                :actions [{:name :action/stripe-create-payout}]
-                :from :state/accepted
-                :to :state/delivered}
-
-               {:name :transition/cancel
-                :actor :actor.role/operator
-                :actions [{:name :action/cancel-booking}
-                          {:name :action/calculate-full-refund}
-                          {:name :action/stripe-refund-charge}]
-                :from :state/accepted
-                :to :state/cancelled}
-
-               {:name :transition/review-1-by-provider
-                :actor :actor.role/provider
-                :actions [{:name :action/post-review-by-provider}]
-                :from :state/delivered
-                :to :state/reviewed-by-provider}
-
-               {:name :transition/review-2-by-provider
-                :actor :actor.role/provider
-                :actions [{:name :action/post-review-by-provider}
-                          {:name :action/publish-reviews}]
-                :from :state/reviewed-by-customer
-                :to :state/reviewed}
-
-               {:name :transition/review-1-by-customer
-                :actor :actor.role/customer
-                :actions [{:name :action/post-review-by-customer}]
-                :from :state/delivered
-                :to :state/reviewed-by-customer}
-
-               {:name :transition/review-2-by-customer
-                :actor :actor.role/customer
-                :actions [{:name :action/post-review-by-customer}
-                          {:name :action/publish-reviews}]
-                :from :state/reviewed-by-provider
-                :to :state/reviewed}
-
-               {:name :transition/expire-review-period
-                :at {:fn/plus [{:fn/timepoint [:time/booking-end]}
-                               {:fn/period ["P7D"]}]}
-                :actions []
-                :from :state/delivered
-                :to :state/reviewed}
-
-               {:name :transition/expire-provider-review-period
-                :at {:fn/plus [{:fn/timepoint [:time/booking-end]}
-                               {:fn/period ["P7D"]}]}
-                :actions [{:name :action/publish-reviews}]
-                :from :state/reviewed-by-customer
-                :to :state/reviewed}
-
-               {:name :transition/expire-customer-review-period
-                :at {:fn/plus [{:fn/timepoint [:time/booking-end]}
-                               {:fn/period ["P7D"]}]}
-                :actions [{:name :action/publish-reviews}]
-                :from :state/reviewed-by-provider
-                :to :state/reviewed}]
-
- :notifications [{:name :notification/new-booking-request
-                  :on :transition/request
-                  :to :actor.role/provider
-                  :template :new-booking-request}
-
-                 {:name :notification/new-booking-request-after-enquiry
-                  :on :transition/request-after-enquiry
-                  :to :actor.role/provider
-                  :template :new-booking-request}
-
-                 {:name :notification/booking-request-accepted
-                  :on :transition/accept
-                  :to :actor.role/customer
-                  :template :booking-request-accepted}
-
-                 {:name :notification/booking-request-declined
-                  :on :transition/decline
-                  :to :actor.role/customer
-                  :template :booking-request-declined}
-
-                 {:name :notification/booking-request-auto-declined
-                  :on :transition/expire
-                  :to :actor.role/customer
-                  :template :booking-request-auto-declined}
-
-                 {:name :notification/money-paid
-                  :on :transition/complete
-                  :to :actor.role/provider
-                  :template :money-paid}
-
-                 {:name :notification/review-period-start-provider
-                  :on :transition/complete
-                  :to :actor.role/provider
-                  :template :review-by-provider-wanted}
-
-                 {:name :notification/review-period-start-customer
-                  :on :transition/complete
-                  :to :actor.role/customer
-                  :template :review-by-customer-wanted}
-
-                 {:name :notification/review-by-provider-first
-                  :on :transition/review-1-by-provider
-                  :to :actor.role/customer
-                  :template :review-by-other-party-unpublished}
-
-                 {:name :notification/review-by-customer-first
-                  :on :transition/review-1-by-customer
-                  :to :actor.role/provider
-                  :template :review-by-other-party-unpublished}
-
-                 {:name :notification/review-by-provider-second
-                  :on :transition/review-2-by-provider
-                  :to :actor.role/customer
-                  :template :review-by-other-party-published}
-
-                 {:name :notification/review-by-customer-second
-                  :on :transition/review-2-by-customer
-                  :to :actor.role/provider
-                  :template :review-by-other-party-published}]}
+{:format :v3,
+ :transitions
+ [{:name :transition/enquire,
+   :actor :actor.role/customer,
+   :actions [],
+   :to :state/enquiry}
+  {:name :transition/request-payment,
+   :actor :actor.role/customer,
+   :actions
+   [{:name :action/create-booking,
+     :config {:observe-availability? true}}
+    {:name :action/calculate-tx-nightly-total-price}
+    {:name :action/calculate-tx-provider-commission,
+     :config {:commission 0.1M}}
+    {:name :action/stripe-create-payment-intent}],
+   :to :state/pending-payment}
+  {:name :transition/request-payment-after-enquiry,
+   :actor :actor.role/customer,
+   :actions
+   [{:name :action/create-booking,
+     :config {:observe-availability? true}}
+    {:name :action/calculate-tx-nightly-total-price}
+    {:name :action/calculate-tx-provider-commission,
+     :config {:commission 0.1M}}
+    {:name :action/stripe-create-payment-intent}],
+   :from :state/enquiry,
+   :to :state/pending-payment}
+  {:name :transition/expire-payment,
+   :at
+   {:fn/plus
+    [{:fn/timepoint [:time/first-entered-state :state/pending-payment]}
+     {:fn/period ["PT15M"]}]},
+   :actions
+   [{:name :action/decline-booking}
+    {:name :action/calculate-full-refund}
+    {:name :action/stripe-refund-payment}],
+   :from :state/pending-payment,
+   :to :state/payment-expired}
+  {:name :transition/confirm-payment,
+   :actor :actor.role/customer,
+   :actions [{:name :action/stripe-confirm-payment-intent}],
+   :from :state/pending-payment,
+   :to :state/preauthorized}
+  {:name :transition/accept,
+   :actor :actor.role/provider,
+   :actions
+   [{:name :action/accept-booking}
+    {:name :action/stripe-capture-payment-intent}],
+   :from :state/preauthorized,
+   :to :state/accepted}
+  {:name :transition/decline,
+   :actor :actor.role/provider,
+   :actions
+   [{:name :action/decline-booking}
+    {:name :action/calculate-full-refund}
+    {:name :action/stripe-refund-payment}],
+   :from :state/preauthorized,
+   :to :state/declined}
+  {:name :transition/expire,
+   :at
+   {:fn/min
+    [{:fn/plus
+      [{:fn/timepoint [:time/first-entered-state :state/preauthorized]}
+       {:fn/period ["P6D"]}]}
+     {:fn/plus
+      [{:fn/timepoint [:time/booking-end]} {:fn/period ["P1D"]}]}]},
+   :actions
+   [{:name :action/decline-booking}
+    {:name :action/calculate-full-refund}
+    {:name :action/stripe-refund-payment}],
+   :from :state/preauthorized,
+   :to :state/declined}
+  {:name :transition/complete,
+   :at {:fn/timepoint [:time/booking-end]},
+   :actions [{:name :action/stripe-create-payout}],
+   :from :state/accepted,
+   :to :state/delivered}
+  {:name :transition/cancel,
+   :actor :actor.role/operator,
+   :actions
+   [{:name :action/cancel-booking}
+    {:name :action/calculate-full-refund}
+    {:name :action/stripe-refund-payment}],
+   :from :state/accepted,
+   :to :state/cancelled}
+  {:name :transition/review-1-by-provider,
+   :actor :actor.role/provider,
+   :actions [{:name :action/post-review-by-provider}],
+   :from :state/delivered,
+   :to :state/reviewed-by-provider}
+  {:name :transition/review-2-by-provider,
+   :actor :actor.role/provider,
+   :actions
+   [{:name :action/post-review-by-provider}
+    {:name :action/publish-reviews}],
+   :from :state/reviewed-by-customer,
+   :to :state/reviewed}
+  {:name :transition/review-1-by-customer,
+   :actor :actor.role/customer,
+   :actions [{:name :action/post-review-by-customer}],
+   :from :state/delivered,
+   :to :state/reviewed-by-customer}
+  {:name :transition/review-2-by-customer,
+   :actor :actor.role/customer,
+   :actions
+   [{:name :action/post-review-by-customer}
+    {:name :action/publish-reviews}],
+   :from :state/reviewed-by-provider,
+   :to :state/reviewed}
+  {:name :transition/expire-review-period,
+   :at
+   {:fn/plus
+    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
+   :actions [],
+   :from :state/delivered,
+   :to :state/reviewed}
+  {:name :transition/expire-provider-review-period,
+   :at
+   {:fn/plus
+    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
+   :actions [{:name :action/publish-reviews}],
+   :from :state/reviewed-by-customer,
+   :to :state/reviewed}
+  {:name :transition/expire-customer-review-period,
+   :at
+   {:fn/plus
+    [{:fn/timepoint [:time/booking-end]} {:fn/period ["P7D"]}]},
+   :actions [{:name :action/publish-reviews}],
+   :from :state/reviewed-by-provider,
+   :to :state/reviewed}],
+ :notifications
+ [{:name :notification/new-booking-request,
+   :on :transition/confirm-payment,
+   :to :actor.role/provider,
+   :template :new-booking-request}
+  {:name :notification/booking-request-accepted,
+   :on :transition/accept,
+   :to :actor.role/customer,
+   :template :booking-request-accepted}
+  {:name :notification/booking-request-declined,
+   :on :transition/decline,
+   :to :actor.role/customer,
+   :template :booking-request-declined}
+  {:name :notification/booking-request-auto-declined,
+   :on :transition/expire,
+   :to :actor.role/customer,
+   :template :booking-request-auto-declined}
+  {:name :notification/money-paid,
+   :on :transition/complete,
+   :to :actor.role/provider,
+   :template :money-paid}
+  {:name :notification/review-period-start-provider,
+   :on :transition/complete,
+   :to :actor.role/provider,
+   :template :review-by-provider-wanted}
+  {:name :notification/review-period-start-customer,
+   :on :transition/complete,
+   :to :actor.role/customer,
+   :template :review-by-customer-wanted}
+  {:name :notification/review-by-provider-first,
+   :on :transition/review-1-by-provider,
+   :to :actor.role/customer,
+   :template :review-by-other-party-unpublished}
+  {:name :notification/review-by-customer-first,
+   :on :transition/review-1-by-customer,
+   :to :actor.role/provider,
+   :template :review-by-other-party-unpublished}
+  {:name :notification/review-by-provider-second,
+   :on :transition/review-2-by-provider,
+   :to :actor.role/customer,
+   :template :review-by-other-party-published}
+  {:name :notification/review-by-customer-second,
+   :on :transition/review-2-by-customer,
+   :to :actor.role/provider,
+   :template :review-by-other-party-published}]}

--- a/test-process/sample-context.json
+++ b/test-process/sample-context.json
@@ -1,0 +1,224 @@
+{
+  "recipient" : {
+    "id" : "fd180cc2-a99c-4e43-b960-9b94daec5265",
+    "first-name" : "Joe",
+    "last-name" : "Dunphy",
+    "display-name" : "Joe D",
+    "public-data" : {
+      "phoneNumberVerified" : true
+    },
+    "protected-data" : {
+      "phoneNumber" : "123456"
+    },
+    "private-data" : {
+      "language" : "en"
+    }
+  },
+  "recipient-role" : "provider",
+  "other-party" : {
+    "id" : "ef7f40d5-da66-489a-957b-641313b68204",
+    "first-name" : "Jane",
+    "last-name" : "Pritchett",
+    "display-name" : "Jane P",
+    "public-data" : {
+      "phoneNumberVerified" : true
+    },
+    "protected-data" : {
+      "phoneNumber" : "789101112"
+    },
+    "private-data" : {
+      "language" : "fr"
+    }
+  },
+  "marketplace" : {
+    "name" : "Bikesoil",
+    "url" : "https://www.sharetribe.com"
+  },
+  "transaction" : {
+    "booking" : {
+      "start" : {
+        "year" : 2017,
+        "month" : 12,
+        "day" : 1,
+        "hours" : 0,
+        "minutes" : 0,
+        "seconds" : 0,
+        "milliseconds" : 0
+      },
+      "end" : {
+        "year" : 2017,
+        "month" : 12,
+        "day" : 12,
+        "hours" : 0,
+        "minutes" : 0,
+        "seconds" : 0,
+        "milliseconds" : 0
+      },
+      "displayStart" : {
+        "year" : 2017,
+        "month" : 12,
+        "day" : 1,
+        "hours" : 0,
+        "minutes" : 0,
+        "seconds" : 0,
+        "milliseconds" : 0
+      },
+      "displayEnd" : {
+        "year" : 2017,
+        "month" : 12,
+        "day" : 12,
+        "hours" : 0,
+        "minutes" : 0,
+        "seconds" : 0,
+        "milliseconds" : 0
+      }
+    },
+    "listing" : {
+      "id" : "d892dfe6-9407-4400-9e81-8100d7a87b7f",
+      "title" : "Wooden sauna",
+      "private-data" : { },
+      "public-data" : { },
+      "metadata" : { },
+      "availability-plan" : {
+        "type" : "availability-plan/time",
+        "timezone" : "Europe/Helsinki"
+      }
+    },
+    "delayed-transition" : {
+      "run-at" : {
+        "year" : 2017,
+        "month" : 11,
+        "day" : 29,
+        "hours" : 0,
+        "minutes" : 0,
+        "seconds" : 0,
+        "milliseconds" : 0
+      }
+    },
+    "payout-total" : {
+      "amount" : 810,
+      "currency" : "USD"
+    },
+    "protected-data" : { },
+    "customer" : {
+      "id" : "ef7f40d5-da66-489a-957b-641313b68204",
+      "first-name" : "Jane",
+      "last-name" : "Pritchett",
+      "display-name" : "Jane P",
+      "public-data" : {
+        "phoneNumberVerified" : true
+      },
+      "protected-data" : {
+        "phoneNumber" : "789101112"
+      },
+      "private-data" : {
+        "language" : "fr"
+      }
+    },
+    "payin-total" : {
+      "amount" : 900,
+      "currency" : "USD"
+    },
+    "id" : "d8893061-c860-4e44-8d4d-61587a497e6e",
+    "line-items" : [ {
+      "code" : "night",
+      "unit-price" : {
+        "amount" : 300,
+        "currency" : "USD"
+      },
+      "line-total" : {
+        "amount" : 900,
+        "currency" : "USD"
+      },
+      "include-for" : [ "customer", "provider" ],
+      "quantity" : 3
+    }, {
+      "code" : "provider-commission",
+      "unit-price" : {
+        "amount" : 900,
+        "currency" : "USD"
+      },
+      "line-total" : {
+        "amount" : -90,
+        "currency" : "USD"
+      },
+      "include-for" : [ "provider" ],
+      "percentage" : -10
+    } ],
+    "reviews" : [ {
+      "subject" : {
+        "id" : "ef7f40d5-da66-489a-957b-641313b68204",
+        "first-name" : "Jane",
+        "last-name" : "Pritchett",
+        "display-name" : "Jane P",
+        "public-data" : {
+          "phoneNumberVerified" : true
+        },
+        "protected-data" : {
+          "phoneNumber" : "789101112"
+        },
+        "private-data" : {
+          "language" : "fr"
+        }
+      },
+      "content" : "Well done, customer Jane P!"
+    }, {
+      "subject" : {
+        "id" : "fd180cc2-a99c-4e43-b960-9b94daec5265",
+        "first-name" : "Joe",
+        "last-name" : "Dunphy",
+        "display-name" : "Joe D",
+        "public-data" : {
+          "phoneNumberVerified" : true
+        },
+        "protected-data" : {
+          "phoneNumber" : "123456"
+        },
+        "private-data" : {
+          "language" : "en"
+        }
+      },
+      "content" : "Good job, provider Joe D!"
+    } ],
+    "tx-line-items" : [ {
+      "code" : "line-item/night",
+      "unit-price" : {
+        "amount" : 300,
+        "currency" : "USD"
+      },
+      "line-total" : {
+        "amount" : 900,
+        "currency" : "USD"
+      },
+      "include-for" : [ "customer", "provider" ],
+      "quantity" : 3
+    }, {
+      "code" : "line-item/provider-commission",
+      "unit-price" : {
+        "amount" : 900,
+        "currency" : "USD"
+      },
+      "line-total" : {
+        "amount" : -90,
+        "currency" : "USD"
+      },
+      "include-for" : [ "provider" ],
+      "percentage" : -10
+    } ],
+    "provider" : {
+      "id" : "fd180cc2-a99c-4e43-b960-9b94daec5265",
+      "first-name" : "Joe",
+      "last-name" : "Dunphy",
+      "display-name" : "Joe D",
+      "public-data" : {
+        "phoneNumberVerified" : true
+      },
+      "protected-data" : {
+        "phoneNumber" : "123456"
+      },
+      "private-data" : {
+        "language" : "en"
+      }
+    }
+  }
+}

--- a/test-process/templates/booking-request-accepted/booking-request-accepted-html.html
+++ b/test-process/templates/booking-request-accepted/booking-request-accepted-html.html
@@ -1,0 +1,92 @@
+
+{{~#*inline "format-money"~}}
+{{money-amount money}} {{money.currency}}
+{{~/inline~}}
+
+{{~#*inline "format-date"~}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
+{{~/inline~}}
+
+<html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
+  <body>
+    <h1>Your booking request was accepted!</h1>
+
+    {{#with transaction}}
+    <p>{{provider.display-name}} has accepted your booking request for {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}}.</p>
+
+    <p>We have charged {{> format-money money=payin-total}} from your credit card. Here's your receipt.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
+        </tr>
+      </thead>
+      {{#each tx-line-items}}
+        {{#contains include-for "customer"}}
+          {{#eq "line-item/night" code}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
+            </tr>
+            {{/if}}
+          {{/eq}}
+        {{/contains}}
+      {{/each}}
+      </tbody>
+      <tfoot>
+        <tr class="top-row">
+          <th class="left">Total price</th>
+          <th class="right">{{> format-money money=payin-total}}</th>
+        </tr>
+      </tfoot>
+    </table>
+
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/booking-request-accepted/booking-request-accepted-subject.txt
+++ b/test-process/templates/booking-request-accepted/booking-request-accepted-subject.txt
@@ -1,0 +1,1 @@
+{{transaction.provider.display-name}} accepted your booking request!

--- a/test-process/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
+++ b/test-process/templates/booking-request-auto-declined/booking-request-auto-declined-html.html
@@ -1,0 +1,20 @@
+
+{{~#*inline "format-date"~}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
+{{~/inline~}}
+
+<html>
+  <body>
+    <h1>Your booking request has expired.</h1>
+
+    {{#with transaction}}
+    <p>Unfortunately {{provider.display-name}} didn't respond to your booking request for {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}} on time, so the request has expired. You have not been billed.</p>
+    {{/with}}
+
+    <p><a href="{{marketplace.url}}">Try to book something else instead</a></p>
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/booking-request-auto-declined/booking-request-auto-declined-subject.txt
+++ b/test-process/templates/booking-request-auto-declined/booking-request-auto-declined-subject.txt
@@ -1,0 +1,1 @@
+Your booking request has expired

--- a/test-process/templates/booking-request-declined/booking-request-declined-html.html
+++ b/test-process/templates/booking-request-declined/booking-request-declined-html.html
@@ -1,0 +1,20 @@
+
+{{~#*inline "format-date"~}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
+{{~/inline~}}
+
+<html>
+  <body>
+    <h1>Your booking request was declined.</h1>
+
+    {{#with transaction}}
+    <p>Unfortunately {{provider.display-name}} decided to decline your booking request for {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}}. You have not been billed.</p>
+    {{/with}}
+
+    <p><a href="{{marketplace.url}}">Try to book something else instead</a></p>
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/booking-request-declined/booking-request-declined-subject.txt
+++ b/test-process/templates/booking-request-declined/booking-request-declined-subject.txt
@@ -1,0 +1,1 @@
+{{transaction.provider.display-name}} declined your booking request

--- a/test-process/templates/money-paid/money-paid-html.html
+++ b/test-process/templates/money-paid/money-paid-html.html
@@ -1,0 +1,104 @@
+
+{{~#*inline "format-money"~}}
+{{money-amount money}} {{money.currency}}
+{{~/inline~}}
+
+{{~#*inline "format-date"~}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
+{{~/inline~}}
+
+<html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
+  <body>
+    {{#with transaction}}
+    <h1>You have been paid {{> format-money money=payout-total}}</h1>
+
+    <p>We have sent you {{> format-money money=payout-total}} for the booking of {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}} by {{customer.display-name}}. It might take up to 7 days for the money to reach your bank account.</p>
+
+    <p>Here's the breakdown.</p>
+
+    <table>
+      <thead>
+        <tr>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{#each tx-line-items}}
+        {{#contains include-for "provider"}}
+          {{#eq "line-item/night" code}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
+            </tr>
+            {{/if}}
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
+
+          {{#eq "line-item/provider-commission" code}}
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
+        {{/contains}}
+      {{/each}}
+      </tbody>
+      <tfoot>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
+        </tr>
+      </tfoot>
+    </table>
+
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/money-paid/money-paid-subject.txt
+++ b/test-process/templates/money-paid/money-paid-subject.txt
@@ -1,0 +1,1 @@
+You have been paid {{money-amount transaction.payout-total}} {{transaction.payout-total.currency}}

--- a/test-process/templates/new-booking-request/new-booking-request-html.html
+++ b/test-process/templates/new-booking-request/new-booking-request-html.html
@@ -1,0 +1,105 @@
+
+{{~#*inline "format-money"~}}
+{{money-amount money}} {{money.currency}}
+{{~/inline~}}
+
+{{~#*inline "format-date"~}}
+{{date date format="MMM d, YYYY" tz="Etc/UTC"}}
+{{~/inline~}}
+
+<html>
+  <head>
+    <style type="text/css">
+     table {
+       border-collapse: collapse;
+     }
+     .left {
+       text-align: left;
+     }
+     .right {
+       text-align: right;
+       padding-left: 20px;
+     }
+     .bottom-row > td {
+       padding-bottom: 5px;
+     }
+     .top-row {
+       border-top: 1px solid #CCC;
+     }
+     .top-row > td,
+     .top-row > th
+     {
+       padding-top: 5px;
+     }
+    </style>
+  </head>
+  <body>
+    {{#with transaction}}
+    <h1>Please respond to a request by {{customer.display-name}}</h1>
+
+    <p>Good news! {{customer.display-name}} just requested to book {{listing.title}} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}}. Here's the breakdown.</p>
+    <table>
+      <thead>
+        <tr>
+          <td class="left">Start date</td>
+          <td class="right">End date</td>
+        </tr>
+        <tr>
+          <th class="left">{{date booking.start format="EEEE" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="EEEE" tz="Etc/UTC"}}</th>
+        </tr>
+        <tr class="bottom-row">
+          <th class="left">{{date booking.start format="MMM d" tz="Etc/UTC"}}</th>
+          <th class="right">{{date booking.end format="MMM d" tz="Etc/UTC"}}</th>
+        </tr>
+      </thead>
+      <tbody>
+      {{#each tx-line-items}}
+        {{#contains include-for "provider"}}
+          {{#eq "line-item/night" code}}
+            {{#if seats}}
+            <tr class="top-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number units}} {{inflect units "night" "nights"}}</td>
+            </tr>
+            <tr class="bottom-row">
+              <td colspan="2">Seats &times; {{number seats}}</td>
+            </tr>
+            {{else}}
+            <tr class="top-row bottom-row">
+              <td colspan="2">{{> format-money money=unit-price}} &times; {{number quantity}} {{inflect quantity "night" "nights"}}</td>
+            </tr>
+            {{/if}}
+            <tr class="top-row">
+              <th class="left">Subtotal</th>
+              <th class="right">{{> format-money money=line-total}}</th>
+            </tr>
+          {{/eq}}
+
+          {{#eq "line-item/provider-commission" code}}
+            <tr class="bottom-row">
+              <td>{{marketplace.name}} fee</td>
+              <td class="right">{{> format-money money=line-total}}</td>
+            </tr>
+          {{/eq}}
+        {{/contains}}
+      {{/each}}
+      </tbody>
+      <tfoot>
+        <tr class="top-row">
+          <th class="left">You'll make</th>
+          <th class="right">{{> format-money money=payout-total}}</th>
+        </tr>
+      </tfoot>
+    </table>
+
+    <p>You need to accept the request by {{> format-date date=delayed-transition.run-at}}. Otherwise the request will be expired and you won't get paid. If the booked dates won't work for you, you can also choose to decline the request.</p>
+
+    <p><a href="{{marketplace.url}}/sale/{{url-encode id}}/details">Accept or decline the booking</a></p>
+
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/new-booking-request/new-booking-request-subject.txt
+++ b/test-process/templates/new-booking-request/new-booking-request-subject.txt
@@ -1,0 +1,1 @@
+{{transaction.customer.display-name}} has requested to book {{transaction.listing.title}}

--- a/test-process/templates/review-by-customer-wanted/review-by-customer-wanted-html.html
+++ b/test-process/templates/review-by-customer-wanted/review-by-customer-wanted-html.html
@@ -1,0 +1,14 @@
+<html>
+  <body>
+    {{#with transaction}}
+    <h1>How was your experience with {{listing.title}}? Write a review!</h1>
+
+    <p>You recently booked {{listing.title}} from {{provider.display-name}}. Please write a review to describe your experience. Reviews are important part of the {{marketplace.name}} community.</p>
+
+    <p><a href="{{marketplace.url}}/order/{{url-encode id}}/details">Leave a review</a></p>
+    {{/with}}
+
+    <hr />
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/review-by-customer-wanted/review-by-customer-wanted-subject.txt
+++ b/test-process/templates/review-by-customer-wanted/review-by-customer-wanted-subject.txt
@@ -1,0 +1,1 @@
+Write a review for {{transaction.listing.title}}

--- a/test-process/templates/review-by-other-party-published/review-by-other-party-published-html.html
+++ b/test-process/templates/review-by-other-party-published/review-by-other-party-published-html.html
@@ -1,0 +1,23 @@
+<html>
+  <body>
+    {{#with transaction}}
+    <h1>{{other-party.display-name}} wrote you a review. Here's what they wrote.</h1>
+
+    {{#each reviews}}
+      {{#eq recipient.id subject.id}}
+        <blockquote><i>"{{content}}"</i></blockquote>
+      {{/eq}}
+    {{/each}}
+
+    <p>The review has been published on your {{marketplace.name}} profile.</p>
+
+    <p>
+      <a href="{{marketplace.url}}/u/{{url-encode recipient.id}}">View your profile.</a>
+    </p>
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/review-by-other-party-published/review-by-other-party-published-subject.txt
+++ b/test-process/templates/review-by-other-party-published/review-by-other-party-published-subject.txt
@@ -1,0 +1,1 @@
+Read the review {{other-party.display-name}} wrote you

--- a/test-process/templates/review-by-other-party-unpublished/review-by-other-party-unpublished-html.html
+++ b/test-process/templates/review-by-other-party-unpublished/review-by-other-party-unpublished-html.html
@@ -1,0 +1,17 @@
+<html>
+  <body>
+    {{#with transaction}}
+    <h1>Find out what {{other-party.display-name}} wrote!</h1>
+
+    <p>{{other-party.display-name}} has left you a new review. To see what they wrote, please leave them a review to describe your experience.</p>
+
+    <p>
+      <a href="{{marketplace.url}}/{{#eq recipient-role "customer"}}order{{else}}sale{{/eq}}/{{url-encode id}}/details">Leave a review</a>
+    </p>
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/review-by-other-party-unpublished/review-by-other-party-unpublished-subject.txt
+++ b/test-process/templates/review-by-other-party-unpublished/review-by-other-party-unpublished-subject.txt
@@ -1,0 +1,1 @@
+{{other-party.display-name}} wrote you a review

--- a/test-process/templates/review-by-provider-wanted/review-by-provider-wanted-html.html
+++ b/test-process/templates/review-by-provider-wanted/review-by-provider-wanted-html.html
@@ -1,0 +1,15 @@
+<html>
+  <body>
+    {{#with transaction}}
+    <h1>How was your experience with {{customer.display-name}}? Write a review!</h1>
+
+    <p>{{customer.display-name}} recently booked {{listing.title}} from you. Please write {{customer.display-name}} a review to describe your experience. Reviews are important part of the {{marketplace.name}} community.</p>
+
+    <p><a href="{{marketplace.url}}/sale/{{url-encode id}}/details">Leave a review</a></p>
+    {{/with}}
+
+    <hr />
+
+    <p>You have received this email notification because you are a member of {{marketplace.name}}. If you no longer wish to receive these emails, please contact {{marketplace.name}} team.</p>
+  </body>
+</html>

--- a/test-process/templates/review-by-provider-wanted/review-by-provider-wanted-subject.txt
+++ b/test-process/templates/review-by-provider-wanted/review-by-provider-wanted-subject.txt
@@ -1,0 +1,1 @@
+Write a review for {{transaction.customer.display-name}}

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,6 +484,11 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
   integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
 
+is-wsl@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -615,6 +620,13 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+open@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.0.0.tgz#7e52999b14eb73f90f0f0807fe93897c4ae73ec9"
+  integrity sha512-K6EKzYqnwQzk+/dzJAQSBORub3xlBTxMz+ntpZpH/LyCa1o6KjXhuN+2npAaI9jaSmU3R1Q8NWf4KUWcyytGsQ==
+  dependencies:
+    is-wsl "^2.1.0"
+
 os-browserify@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
@@ -745,6 +757,13 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
 
 rimraf@^3.0.0:
   version "3.0.0"
@@ -918,6 +937,13 @@ tmp@^0.0.33:
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
   dependencies:
     os-tmpdir "~1.0.2"
+
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR adds a new `notifications preview` command. It takes a `--template` options that points to a template directory and:

1. Sends the template subject and html to the `/notifications/preview` API endpoint
2. Prints out the rendered preview subject and text
3. Creates a temporary HTML file with the subject injected in the `<title>`
4. Opens the created HTML file in a browser

## Template with errors

<img width="809" alt="Screen Shot 2019-11-05 at 14 03 05" src="https://user-images.githubusercontent.com/53923/68206358-2f686b00-ffd5-11e9-8572-a35211653048.png">

## CLI output of preview subject and text

<img width="809" alt="Screen Shot 2019-11-05 at 14 07 55" src="https://user-images.githubusercontent.com/53923/68206571-b61d4800-ffd5-11e9-9c07-e7fbc2dc4c64.png">

## Preview HTML opened automatically in a browser

See the subject injected in the `<title>`

![Screen Shot 2019-11-05 at 14 02 54](https://user-images.githubusercontent.com/53923/68206437-59219200-ffd5-11e9-8512-7b686c45f35f.png)
