### PR TITLE
Notifications send command

### DIFF
--- a/src/sharetribe/flex_cli/commands/notifications.cljs
+++ b/src/sharetribe/flex_cli/commands/notifications.cljs
@@ -1,5 +1,7 @@
 (ns sharetribe.flex-cli.commands.notifications
-  (:require [sharetribe.flex-cli.commands.notifications.preview :as notifications.preview]))
+  (:require [sharetribe.flex-cli.commands.notifications.preview :as notifications.preview]
+            [sharetribe.flex-cli.commands.notifications.send :as notifications.send]))
 
 (def cmd {:name "notifications"
-          :sub-cmds [notifications.preview/cmd]})
+          :sub-cmds [notifications.preview/cmd
+                     notifications.send/cmd]})

--- a/src/sharetribe/flex_cli/commands/notifications/send.cljs
+++ b/src/sharetribe/flex_cli/commands/notifications/send.cljs
@@ -1,0 +1,50 @@
+(ns sharetribe.flex-cli.commands.notifications.send
+  (:require [clojure.string :as str]
+            [clojure.core.async :as async :refer [go <!]]
+            [sharetribe.flex-cli.async-util :refer [<? go-try]]
+            [sharetribe.flex-cli.io-util :as io-util]
+            [sharetribe.flex-cli.process-util :as process-util]
+            [sharetribe.flex-cli.api.client :as api.client :refer [do-post]]
+            [sharetribe.flex-cli.exception :as exception]))
+
+(declare send)
+
+(def cmd {:name "send"
+          :handler #'send
+          :desc "send a preview of an email template to the logged in admin"
+          :opts [{:id :template
+                  :long-opt "--template"
+                  :desc "path to a template directory"
+                  :required "TEMPLATE_DIR"
+                  :missing "--template is required"}
+                 {:id :context
+                  :long-opt "--context"
+                  :desc "path to an email rendering context JSON file"
+                  :required "CONTEXT_FILE_PATH"}]})
+
+(defmethod exception/format-exception :notifications.send/api-call-failed [_ _ data]
+  (case (:code (api.client/api-error data))
+    :invalid-template (process-util/format-invalid-template-error data)
+    (api.client/default-error-format data)))
+
+(defn send [params ctx]
+  (go-try
+   (let [{:keys [api-client marketplace]} ctx
+         {:keys [template context]} params
+         tmpl (io-util/read-template template)
+         body (cond-> {:template tmpl}
+                context (assoc :template-context (io-util/load-file context)))
+         res (try
+               (<? (do-post api-client
+                            "/notifications/send"
+                            {:marketplace marketplace}
+                            body))
+               (catch js/Error e
+                 (throw
+                  (api.client/retype-ex e :notifications.send/api-call-failed))))
+         {:keys [admin-email] :as tmpl} (:data res)]
+     (println "Sent a preview to" admin-email))))
+
+(comment
+  (sharetribe.flex-cli.core/main-dev-str "notifications send -m bike-soil --template test-process/templates/booking-request-accepted --context test-process/sample-context.json")
+  )


### PR DESCRIPTION
Builds on top of #70 

This PR adds a new `notifications send` command that can be used to render a given local template and send it to the email address of the admin user.

<img width="789" alt="Screen Shot 2019-11-07 at 13 27 13" src="https://user-images.githubusercontent.com/53923/68385522-a717d080-0162-11ea-9504-b6181f50c9dd.png">
<img width="981" alt="Screen Shot 2019-11-07 at 13 27 48" src="https://user-images.githubusercontent.com/53923/68385529-abdc8480-0162-11ea-9b55-e5626256cd80.png">
<img width="544" alt="Screen Shot 2019-11-07 at 13 27 59" src="https://user-images.githubusercontent.com/53923/68385535-ae3ede80-0162-11ea-9298-9e118e2c22a7.png">
