### PR TITLE
Allow new Stripe api version (2019-12-03)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "flex-cli",
   "description": "Sharetribe Flex CLI",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/src/sharetribe/flex_cli/cli_info.cljs
+++ b/src/sharetribe/flex_cli/cli_info.cljs
@@ -1,4 +1,4 @@
 (ns sharetribe.flex-cli.cli-info)
 
 (def ^:const bin "flex-cli")
-(def ^:const version "1.3.0")
+(def ^:const version "1.3.1")

--- a/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
@@ -8,7 +8,9 @@
 
 (declare update-version)
 
-(def ^:const supported-versions #{"2019-02-19" "2019-09-09"})
+;; Order matters, keep the newest version first in the vector
+;; Prompt shows options in order
+(def ^:const supported-versions ["2019-12-03" "2019-09-09" "2019-02-19"])
 
 (def cmd {:name "update-version"
           :handler #'update-version


### PR DESCRIPTION
Allow the 2019-12-03 Stripe API version and flip the order in prompt so that the newest API is always first.