### PR TITLE
Privileged transitions

### DIFF
--- a/src/sharetribe/flex_cli/commands/process.cljs
+++ b/src/sharetribe/flex_cli/commands/process.cljs
@@ -77,9 +77,15 @@
     (io-util/print-table ks (map format-state states)))
   (println) (println))
 
-(defn- format-transition [transition]
+(defn- format-actor [actor privileged?]
+  (let [actor-role (io-util/kw->title actor)]
+    (if privileged?
+      (str actor-role " (privileged transition)")
+      actor-role)))
+
+(defn- format-transition [{:keys [privileged?] :as transition}]
   (-> transition
-      (update :actor io-util/kw->title)
+      (update :actor format-actor privileged?)
       (update :name io-util/namespaced-str)
       (update :from io-util/namespaced-str)
       (update :to io-util/namespaced-str)

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -134,6 +134,16 @@
     {:msg (str "Unreachable state: " state)
      :loc (location tr)}))
 
+(defphraser tempelhof.spec/transition-is-privileged-if-privileged-actions?
+  [{:keys [tx-process]} {:keys [val] :as problems}]
+  (let [offending-actions (tempelhof.spec/privileged-actions val)]
+    {:msg (str "Invalid transition " (:name val)
+               ".\nActions that require privileged context have been defined but the transition is not marked as privileged"
+               ". Add :privileged? true to transition properties."
+               "\nActions that require privileged context are: "
+               (str/join ", " offending-actions))
+     :loc (location val)}))
+
 ;; Actions
 ;;
 

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -83,6 +83,12 @@
              "You gave: " (invalid-val val))
    :loc (find-first-loc tx-process problem)})
 
+(defphraser boolean?
+  [{:keys [tx-process]} {:keys [val] :as problem}]
+  {:msg (str "Invalid " (config-type problem) ". "
+             (invalid-key problem) " must be a boolean value true or false. "
+             "You gave: " (invalid-val val))
+   :loc (find-first-loc tx-process problem)})
 
 ;; Process
 ;;

--- a/src/sharetribe/tempelhof/spec.cljs
+++ b/src/sharetribe/tempelhof/spec.cljs
@@ -77,6 +77,7 @@
 (s/def :tx-process.transition/name keyword?)
 (s/def :tx-process.transition/from keyword?)
 (s/def :tx-process.transition/to keyword?)
+(s/def :tx-process.transition/privileged? boolean?)
 
 ;; Note: We may want to force migration to single actor by saying that
 ;;
@@ -153,7 +154,8 @@
                  :opt-un [:tx-process.transition/actions
                           :tx-process.transition/actor
                           :tx-process.transition/at
-                          :tx-process.transition/from])
+                          :tx-process.transition/from
+                          :tx-process.transition/privileged?])
          transition-has-either-actor-or-at?))
 
 (defn unique-transition-names? [transitions]

--- a/test-process/process.edn
+++ b/test-process/process.edn
@@ -3,7 +3,8 @@
  [{:name :transition/enquire,
    :actor :actor.role/customer,
    :actions [],
-   :to :state/enquiry}
+   :to :state/enquiry
+   :privileged? true}
   {:name :transition/request-payment,
    :actor :actor.role/customer,
    :actions


### PR DESCRIPTION
Adds understanding of privileged transitions to Flex CLI.

1. Show privileged transitions when printing process description:

```text
States

Name           In                                                 Out
state/initial                                                     transition/enquire-privileged, transition/enquire
state/enquiry  transition/enquire-privileged, transition/enquire


Transitions

Name                           From           To             Actor
transition/enquire-privileged  state/initial  state/enquiry  Customer (privileged transition)
transition/enquire             state/initial  state/enquiry  Customer
```

```text
Name
  transition/enquire-privileged
From
  state/initial
To
  state/enquiry
Actor
  Customer (privileged transition)
At
  -

Actions

Name                                 Config
:action.initializer/init-listing-tx
:action/privileged-set-line-items

Notifications

-
```

2. Validate that if a transition has privileged actions then it must be marked as privileged:

<img width="1086" alt="Screenshot 2020-05-07 at 23 01 48" src="https://user-images.githubusercontent.com/271845/81341389-1f336480-90ba-11ea-8a94-4060b1c5e011.png">
