### PR TITLE
Commands to manage listing approvals

### DIFF
--- a/src/sharetribe/flex_cli/command_defs.cljs
+++ b/src/sharetribe/flex_cli/command_defs.cljs
@@ -7,7 +7,8 @@
             [sharetribe.flex-cli.commands.search-schema :as search-schema]
             [sharetribe.flex-cli.commands.stripe :as stripe]
             [sharetribe.flex-cli.commands.version :as version]
-            [sharetribe.flex-cli.commands.notifications :as notifications]))
+            [sharetribe.flex-cli.commands.notifications :as notifications]
+            [sharetribe.flex-cli.commands.listing-approval :as listing-approval]))
 
 (def marketplace-opt
   {:id :marketplace
@@ -52,7 +53,8 @@
     stripe/cmd
     process/cmd
     search-schema/cmd
-    notifications/cmd]})
+    notifications/cmd
+    listing-approval/cmd]})
 
 (defn- with-marketplace-opt [cmd]
   (if (:no-marketplace? cmd)

--- a/src/sharetribe/flex_cli/commands/listing_approval.cljs
+++ b/src/sharetribe/flex_cli/commands/listing_approval.cljs
@@ -36,7 +36,7 @@
 (defn query-listing-approval [_ ctx]
   (let [{:keys [api-client marketplace]} ctx]
     (go-try
-     (let [res (<? (do-get api-client "/listing-approval/query" {:marketplace marketplace}))]
+     (let [res (<? (do-get api-client "/marketplace/show" {:marketplace marketplace}))]
        (if (-> res :data :marketplace/requireListingApproval)
          (println "Listing approvals are enabled in" marketplace)
          (println "Listing approvals are disabled in" marketplace))))))

--- a/src/sharetribe/flex_cli/commands/listing_approval.cljs
+++ b/src/sharetribe/flex_cli/commands/listing_approval.cljs
@@ -1,0 +1,48 @@
+(ns sharetribe.flex-cli.commands.listing-approval
+  (:require [sharetribe.flex-cli.api.client :refer [do-get do-post]]
+            [clojure.core.async :as async :refer [go <!]]
+            [sharetribe.flex-cli.async-util :refer [<? go-try]]))
+
+(declare query-listing-approval)
+(declare enable-listing-approval)
+(declare disable-listing-approval)
+
+(def enable-cmd {:name "enable"
+                 :handler #'enable-listing-approval
+                 :desc "enable listing approvals"})
+
+(def disable-cmd {:name "disable"
+                  :handler #'disable-listing-approval
+                  :desc "disable listing approvals"})
+
+(def cmd {:name "listing-approval"
+          :handler #'query-listing-approval
+          :desc "check if listing approvals are enabled or disabled"
+          :sub-cmds [enable-cmd
+                     disable-cmd]})
+
+(defn enable-listing-approval [_ ctx]
+  (let [{:keys [api-client marketplace]} ctx]
+    (go-try
+     (let [res (<? (do-post api-client "/listing-approval/enable" {:marketplace marketplace} {}))]
+       (println "Successfully enabled listing approvals in" marketplace)))))
+
+(defn disable-listing-approval [_ ctx]
+  (let [{:keys [api-client marketplace]} ctx]
+    (go-try
+     (let [res (<? (do-post api-client "/listing-approval/disable" {:marketplace marketplace} {}))]
+       (println "Successfully disabled listing approvals in" marketplace)))))
+
+(defn query-listing-approval [_ ctx]
+  (let [{:keys [api-client marketplace]} ctx]
+    (go-try
+     (let [res (<? (do-get api-client "/listing-approval/query" {:marketplace marketplace}))]
+       (if (-> res :data :marketplace/requireListingApproval)
+         (println "Listing approvals are enabled in" marketplace)
+         (println "Listing approvals are disabled in" marketplace))))))
+
+(comment
+  (sharetribe.flex-cli.core/main-dev-str "listing-approval -m bike-soil")
+  (sharetribe.flex-cli.core/main-dev-str "listing-approval enable -m bike-soil")
+  (sharetribe.flex-cli.core/main-dev-str "listing-approval disable -m bike-soil")
+  )

--- a/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
+++ b/src/sharetribe/flex_cli/commands/stripe/update_version.cljs
@@ -14,15 +14,15 @@
 
 (def cmd {:name "update-version"
           :handler #'update-version
-          :desc "Update Stripe API version in use."
+          :desc "update Stripe API version in use"
           :opts [{:id :version
                   :long-opt "--version"
                   :required "VERSION"
-                  :desc (str "Stripe API version to update to. One of: " (str/join ", " supported-versions) ".")}
+                  :desc (str "Stripe API version to update to. One of: " (str/join ", " supported-versions))}
                  {:id :force
                   :long-opt "--force"
                   :short-opt "-f"
-                  :desc "Force Stripe API version update without confirmation."}]})
+                  :desc "force Stripe API version update without confirmation"}]})
 
 (defn ensure-valid-version! [version]
   (when-not ((set supported-versions) version)


### PR DESCRIPTION
This PR adds a new command `listing-approval` and its two sub-commands `enable` and `disable` to manage the marketplace listing approval setting.