### PR TITLE
Operator transitions and transaction metadata action

### DIFF
--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -236,6 +236,18 @@
             :loc (location (:at n))})
          invalid-timepoints)))
 
+;; Actor validation
+;;
+
+(defphraser tempelhof.spec/valid-initial-transition-actor?
+  [{:keys [tx-process]} _]
+  (let [invalid-transitions (tempelhof.spec/invalid-actor-in-initial-transitions tx-process)]
+    (map (fn [t]
+           {:msg (str "Invalid transition " (:name t) ". "
+                      "The value of :actor must be :actor.role/customer for all initial transitions.")
+            :loc (location t)})
+         invalid-transitions)))
+
 ;; Not sure if this is a good idea?... But if it is it should be moved
 ;; to a util lib.
 (def error-arrow (.bold.red chalk "\u203A"))

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -151,6 +151,7 @@
   [{:keys [tx-process]} {:keys [val] :as problem}]
   {:msg (str "Unknown action name: " (invalid-val val) ". Available actions are:\n"
              (->> tempelhof.spec/action-names
+                  sort
                   (map #(str "  " %))   ; Padding
                   (str/join "\n")))     ; Print one per line
    :loc (find-first-loc tx-process problem)})

--- a/src/sharetribe/tempelhof/process_validation.cljs
+++ b/src/sharetribe/tempelhof/process_validation.cljs
@@ -134,12 +134,12 @@
     {:msg (str "Unreachable state: " state)
      :loc (location tr)}))
 
-(defphraser tempelhof.spec/transition-is-privileged-if-privileged-actions?
+(defphraser tempelhof.spec/transition-with-trusted-context-if-privileged-actions?
   [{:keys [tx-process]} {:keys [val] :as problems}]
   (let [offending-actions (tempelhof.spec/privileged-actions val)]
     {:msg (str "Invalid transition " (:name val)
-               ".\nActions that require privileged context have been defined but the transition is not marked as privileged"
-               ". Add :privileged? true to transition properties."
+               ".\nActions that require trusted context have been defined but the transition is not marked as privileged"
+               ". Either add :privileged? true to transition properties or set actor to :actor.role/operator."
                "\nActions that require privileged context are: "
                (str/join ", " offending-actions))
      :loc (location val)}))

--- a/src/sharetribe/tempelhof/spec.cljs
+++ b/src/sharetribe/tempelhof/spec.cljs
@@ -330,6 +330,13 @@
                        (map #(timepoint-error % name at))))
             (:notifications process))))
 
+(defn invalid-actor-in-initial-transitions [process]
+  (->> process
+       :transitions
+       (remove :from)
+       (remove (fn [{:keys [actor]}]
+                 (= :actor.role/customer actor)))))
+
 (defn valid-transitions-in-transition-timepoints? [process]
   (empty? (invalid-transitions-in-transition-timepoints process)))
 
@@ -342,6 +349,9 @@
 (defn valid-states-in-notification-timepoints? [process]
   (empty? (invalid-states-in-notification-timepoints process)))
 
+(defn valid-initial-transition-actor? [process]
+  (empty? (invalid-actor-in-initial-transitions process)))
+
 (s/def :tempelhof/tx-process
   (s/and
    (s/keys :req-un [:tx-process/format
@@ -352,4 +362,5 @@
    valid-transitions-in-transition-timepoints?
    valid-states-in-transition-timepoints?
    valid-transitions-in-notification-timepoints?
-   valid-states-in-notification-timepoints?))
+   valid-states-in-notification-timepoints?
+   valid-initial-transition-actor?))

--- a/src/sharetribe/tempelhof/spec.cljs
+++ b/src/sharetribe/tempelhof/spec.cljs
@@ -93,7 +93,8 @@
 ;;                               :into #{})))
 
 
-(def privileged-action-names #{:action/privileged-set-line-items})
+(def privileged-action-names #{:action/privileged-set-line-items
+                               :action/privileged-update-metadata})
 
 (def nonprivileged-action-names #{:action.initializer/init-listing-tx
                                   :action/create-booking
@@ -162,10 +163,12 @@
         (map :name)
         set)))
 
-(defn transition-is-privileged-if-privileged-actions?
+(defn transition-with-trusted-context-if-privileged-actions?
   [transition]
-  (let [privileged? (:privileged? transition)]
+  (let [privileged? (:privileged? transition)
+        operator? (= :actor.role/operator (:actor transition))]
     (or privileged?
+        operator?
         (empty? (privileged-actions transition)))))
 
 (s/def :tx-process/transition
@@ -177,7 +180,7 @@
                           :tx-process.transition/from
                           :tx-process.transition/privileged?])
          transition-has-either-actor-or-at?
-         transition-is-privileged-if-privileged-actions?))
+         transition-with-trusted-context-if-privileged-actions?))
 
 (defn unique-transition-names? [transitions]
   (let [names (map :name transitions)]


### PR DESCRIPTION
Privileged actions require trusted context, which now is possible in two ways: either `privileged? true` transition or when the actor is operator (and the transition is done via Integration API).

Add the new `:action/privileged-update-metadata` to the set of supported actions.