### PR TITLE
Live tail events

### DIFF
--- a/src/sharetribe/flex_cli/commands/events.cljs
+++ b/src/sharetribe/flex_cli/commands/events.cljs
@@ -216,10 +216,11 @@
                                     (->> (:data res) (map terse-event-row)))))
               new-wait-time (or (-> res :meta :liveTailPollInterval)
                                 wait-time)
-              chs (if (-> res :data seq)
-                    [stop-loop-ch (async/timeout 250)]
-                    [stop-loop-ch (async/timeout wait-time)])
-              [_ ch] (async/alts! chs)]
+              full-response? (>= (-> res :data count)
+                                 (-> res :meta :perPage))
+              [_ ch] (async/alts! (if full-response?
+                                    [stop-loop-ch (async/timeout 250)]
+                                    [stop-loop-ch (async/timeout wait-time)]))]
           (when-not (= ch stop-loop-ch)
             (recur (-> next-params
                        (assoc :after-seqid last-seqid)

--- a/src/sharetribe/flex_cli/commands/events.cljs
+++ b/src/sharetribe/flex_cli/commands/events.cljs
@@ -8,6 +8,7 @@
             [clojure.string :as str]))
 
 (declare list-events)
+(declare start-live-tail)
 
 (def cmd {:name "events"
           :handler #'list-events
@@ -50,7 +51,29 @@
                   :desc "Print full event data as one JSON string."}
                  {:id :json-pretty
                   :long-opt "--json-pretty"
-                  :desc "Print full event data as indented multi-line JSON string."} ]})
+                  :desc "Print full event data as indented multi-line JSON string."}]
+          :sub-cmds [{:name "tail"
+                      :handler #'start-live-tail
+                      :desc "Tail events live as they happen"
+                      :opts [{:id :resource
+                              :long-opt "--resource"
+                              :desc "Show events for a specific resource ID only."
+                              :required "RESOURCE_ID"}
+                             {:id :filter
+                              :long-opt "--filter"
+                              :desc "Show only events of given types, e.g. '--filter listing/updated,user'."
+                              :required "EVENT_TYPES"}
+                             {:id :limit
+                              :long-opt "--limit"
+                              :short-opt "-l"
+                              :desc "Show given number of latest events and then start tailing (default is 10 and max is 100). Can be combined with other parameters."
+                              :required "NUMBER"}
+                             {:id :json
+                              :long-opt "--json"
+                              :desc "Print full event data as one JSON string."}
+                             {:id :json-pretty
+                              :long-opt "--json-pretty"
+                              :desc "Print full event data as indented multi-line JSON string."}]}]})
 
 (def ^:private param->api-param
   {:resource :resource-id
@@ -144,8 +167,60 @@
             "' for param " (name (api-param->param (first path))) "."))
       (api.client/default-error-format data))))
 
+;; Polling loop for live tailing
+;;
 
-;; Command handler
+(def polling-loop (atom nil))
+
+(defn- stop-polling-loop! []
+  (go
+    (when-let [stop-loop-ch @polling-loop]
+      (async/close! stop-loop-ch))))
+
+(defn- start-polling-loop! [marketplace api-client params]
+  (let [stop-loop-ch (async/chan)
+        {:keys [json json-pretty]} params
+        start-params (if (contains? params :limit)
+                       params
+                       (assoc params :limit 10))]
+
+    (go
+      (<! (stop-polling-loop!))
+      (reset! polling-loop stop-loop-ch)
+
+      (loop [next-params start-params
+             widths nil]
+        (let [res (try (<? (fetch-events marketplace api-client next-params))
+                       (catch js/Error e
+                         (throw
+                          (api.client/retype-ex e :events.query/api-call-failed))))
+              last-seqid (or (-> res :data last :event/data :sequenceId)
+                             (:after-seqid next-params))
+              widths (cond
+                       json (doseq [event-str (map json-str-event (:data res))]
+                              (println event-str))
+                       json-pretty (doseq [event-str (map json-pretty-str-event (:data res))]
+                                     (println event-str))
+                       :else (if-not widths
+                               (io-util/print-table
+                                [:seq-ID :resource-ID :event-type :created-at-local-time :source :actor]
+                                (->> (:data res) (map terse-event-row)))
+                               (io-util/print-table-continuation
+                                [:seq-ID :resource-ID :event-type :created-at-local-time :source :actor]
+                                widths
+                                (->> (:data res) (map terse-event-row)))))
+              chs (if (-> res :data seq)
+                    [stop-loop-ch (async/timeout 250)]
+                    [stop-loop-ch (async/timeout 5000)])
+              [_ ch] (async/alts! chs)]
+          (when-not (= ch stop-loop-ch)
+            (recur (-> next-params
+                       (assoc :after-seqid last-seqid)
+                       (dissoc :limit))
+                   widths)))))))
+
+
+;; Command handlers
 ;;
 
 (defn list-events [params ctx]
@@ -167,7 +242,36 @@
                 (->> (:data res) (map terse-event-row))))))))
 
 
+(defn start-live-tail [params ctx]
+  (let [{:keys [api-client marketplace]} ctx
+        done-chan (async/chan)
+        {:keys [json json-pretty]} params
+        ;; Only print user friendly messages when output is not --json
+        ;; or --json-pretty so that we don't mess up piping json to
+        ;; parser.
+        table-output? (not (or json json-pretty))]
+
+    ;; Setup Ctrl+C handler to terminate process
+    (.on js/process "SIGINT" (fn [_]
+                               (go
+                                 (when table-output?
+                                   (println "Exiting..."))
+                                 (<! (stop-polling-loop!))
+                                 (async/close! done-chan))))
+    (go
+      (when table-output?
+        (println "Starting live tail of events. Type <Ctrl>+C to quit."))
+      (<! (start-polling-loop! marketplace api-client params))
+      (<! done-chan))))
+
+
 (comment
+
+  (sharetribe.flex-cli.core/main-dev-str "help events tail")
+  (sharetribe.flex-cli.core/main-dev-str "events tail -m drivelah -l 5")
+  (sharetribe.flex-cli.core/main-dev-str "events tail -m drivelah -l 10")
+  (stop-polling-loop!)
+
   (sharetribe.flex-cli.core/main-dev-str "help events")
   (sharetribe.flex-cli.core/main-dev-str "events -m bike-soil")
   (sharetribe.flex-cli.core/main-dev-str "events -m bike-soil --limit 3")

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -207,7 +207,30 @@
      (println)
      (println (fmt-headers ks))
      (doseq [row rows]
-       (println (fmt-row row))))))
+       (println (fmt-row row)))
+
+     widths)))
+
+(defn print-table-continuation
+  "Print more rows to continue a table that was printed earlier. Takes
+  previously calculated column widths as the second argument (return
+  value of 'print-table'). Skips printing the header but still needs
+  the column information to order columns. Returns widths through."
+  [ks widths rows]
+  (let [right-pad (fn [s str-width col-width]
+                    (let [pad-len (- col-width str-width)]
+                      (apply str s (when (> pad-len 0)
+                                     (repeat pad-len " ")))))
+        fmt-row (fn [row]
+                  (apply str
+                         (interpose
+                          " "
+                          (for [[col width] (map vector (map #(get row %) ks) widths)]
+                            (right-pad (str col) (count (str col)) width)))))]
+    (doseq [row rows]
+      (println (fmt-row row)))
+
+    widths))
 
 (defn section-title
   "Format title string as section title."


### PR DESCRIPTION
```bash
$ node target/min.js help events tail
Tail events live as they happen

USAGE
  $ flex-cli events tail

OPTIONS
  --filter=EVENT_TYPES              Show only events of given types, e.g. '--filter listing/updated,user'.
  --json                            Print full event data as one JSON string.
  --json-pretty                     Print full event data as indented multi-line JSON string.
  --resource=RESOURCE_ID            Show events for a specific resource ID only.
  -l, --limit=NUMBER                Show given number of latest events and then start tailing (default is 10 and max is 100). Can be combined with other parameters.
  -m, --marketplace=MARKETPLACE_ID  marketplace identifier


$ node target/min.js events tail -m sauna-demo-1 -l 5 --filter user,listing
Starting live tail of events. Type <Ctrl>+C to quit.

Seq ID   Resource ID                           Event type       Created at local time   Source           Actor
1630038  5e504aca-0bdb-4c89-9a21-a8778e17efb9  user/updated     2020-10-06 11:42:32 PM  console
3007716  5df9576a-dec1-4aaa-8651-59fff550e8a6  listing/updated  2020-11-19 7:58:38 PM   marketplace-api  thomas.rocca@sharetribe.com
3462912  5dfb4a42-8937-47b5-b482-44679828939c  user/updated     2020-12-07 3:15:42 PM   console
3462923  5dfb4a42-8937-47b5-b482-44679828939c  user/updated     2020-12-07 3:17:30 PM   console          olli+foobar10@sharetribe.com
3463154  5cb06a2b-4b29-4969-9ce4-2e14769501b1  user/updated     2020-12-07 3:36:28 PM   console
```