### PR TITLE
Push only changed assets

### DIFF
--- a/src/sharetribe/flex_cli/commands/assets.cljs
+++ b/src/sharetribe/flex_cli/commands/assets.cljs
@@ -3,6 +3,7 @@
   (:require [clojure.core.async :as async :refer [go <!]]
             [clojure.set :as set]
             [clojure.string :as str]
+            [chalk]
             [form-data :as FormData]
             [sharetribe.flex-cli.api.client :as api.client :refer [do-multipart-post do-get]]
             [sharetribe.flex-cli.async-util :refer [<? go-try]]
@@ -168,6 +169,10 @@
                               (map (fn [path]
                                      {:path path
                                       :op :delete}))))
+
+         _ (when (seq changed-assets)
+             (let [paths (str/join ", " (map :path changed-assets))]
+               (io-util/log (.green chalk (str "Uploading changed assets: " paths)))))
          no-ops? (and (empty? changed-assets)
                       (empty? delete-assets))]
 

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -243,30 +243,16 @@
 (defn derive-content-hash
   "Derive SHA-1 content hash matching the backend convention.
 
-  Strings are encoded as UTF-8 prior to hashing. Binary inputs are
-  expected to be Buffer/Uint8Array instances. Content is prefixed with
+  Expects Buffer/Uint8Array inputs. Content is prefixed with
   `${byte-count}|` before hashing."
   [content]
-  (when (nil? content)
-    (throw (js/Error. "derive-content-hash expects non-nil content.")))
-  (let [sha (goog.crypt.Sha1.)]
-    (cond
-      (string? content)
-      (let [body-bytes (crypt/stringToUtf8ByteArray content)
-            prefix-bytes (crypt/stringToUtf8ByteArray (str (count body-bytes) "|"))]
-        (.update sha prefix-bytes)
-        (.update sha body-bytes)
-        (crypt/byteArrayToHex (.digest sha)))
-
-      :else
-      (let [byte-length (.-length content)]
-        (when-not (number? byte-length)
-          (throw (js/Error. "derive-content-hash expects string or byte array content.")))
-        (let [body-bytes (js/Array.prototype.slice.call content)
-              prefix-bytes (crypt/stringToUtf8ByteArray (str byte-length "|"))]
-          (.update sha prefix-bytes)
-          (.update sha body-bytes)
-          (crypt/byteArrayToHex (.digest sha)))))))
+  (let [sha (goog.crypt.Sha1.)
+        byte-length (.-length content)]
+    (let [body-bytes (js/Array.prototype.slice.call content)
+          prefix-bytes (crypt/stringToUtf8ByteArray (str byte-length "|"))]
+      (.update sha prefix-bytes)
+      (.update sha body-bytes)
+      (crypt/byteArrayToHex (.digest sha)))))
 
 (defn read-assets
   [path]

--- a/test/sharetribe/flex_cli/commands/assets_test.cljs
+++ b/test/sharetribe/flex_cli/commands/assets_test.cljs
@@ -1,0 +1,28 @@
+(ns sharetribe.flex-cli.commands.assets-test
+  (:require [cljs.test :refer-macros [deftest is testing]]
+            [sharetribe.flex-cli.commands.assets :as assets]))
+
+(deftest filter-assets-to-upload-tests
+  (testing "unchanged assets are skipped"
+    (is (empty?
+         (assets/filter-assets-to-upload
+          [{:path "emails/foo" :content-hash "abc"}]
+          [{:path "emails/foo" :content-hash "abc"}]))))
+
+  (testing "assets without stored metadata default to changed"
+    (is (= [{:path "emails/foo" :content-hash "abc"}]
+           (vec (assets/filter-assets-to-upload
+                 nil
+                 [{:path "emails/foo" :content-hash "abc"}])))))
+
+  (testing "assets missing stored hash are re-uploaded"
+    (is (= [{:path "emails/foo" :content-hash "abc"}]
+           (vec (assets/filter-assets-to-upload
+                 [{:path "emails/foo"}]
+                 [{:path "emails/foo" :content-hash "abc"}])))))
+
+  (testing "hash mismatches trigger upload"
+    (is (= [{:path "emails/foo" :content-hash "def"}]
+           (vec (assets/filter-assets-to-upload
+                 [{:path "emails/foo" :content-hash "abc"}]
+                 [{:path "emails/foo" :content-hash "def"}]))))))

--- a/test/sharetribe/flex_cli/io_util_test.cljs
+++ b/test/sharetribe/flex_cli/io_util_test.cljs
@@ -86,11 +86,6 @@
       (is (= ["userProfile" "metadata" "subscription" "enum" "User subscription."]
              (get-nth-row-output-values table 5))))))
 
-(deftest derive-content-hash-string-test
-  (let [payload "{\"foo\":\"bar\"}"
-        expected (backend-style-hash payload)]
-    (is (= expected (io-util/derive-content-hash payload)))))
-
 (deftest derive-content-hash-binary-test
   (let [payload (js/Uint8Array. #js [0 1 2 3 255 16 32])
         expected (backend-style-hash payload)]

--- a/test/sharetribe/flex_cli/io_util_test.cljs
+++ b/test/sharetribe/flex_cli/io_util_test.cljs
@@ -3,19 +3,7 @@
    [chalk]
    [cljs.test :refer-macros [deftest is testing]]
    [clojure.string :as str]
-   [sharetribe.flex-cli.io-util :as io-util]
-   ["crypto" :as crypto]))
-
-(defn- backend-style-hash [payload]
-  (let [data-buffer (cond
-                      (string? payload) (js/Buffer.from payload "utf8")
-                      (instance? js/Uint8Array payload) (js/Buffer.from payload)
-                      :else (js/Buffer.from payload))
-        prefix (js/Buffer.from (str (.-length data-buffer) "|") "utf8")
-        sha (.createHash crypto "sha1")]
-    (.update sha prefix)
-    (.update sha data-buffer)
-    (.digest sha "hex")))
+   [sharetribe.flex-cli.io-util :as io-util]))
 
 (defn- get-nth-row-output-values [table n]
   (-> table
@@ -88,5 +76,8 @@
 
 (deftest derive-content-hash-binary-test
   (let [payload (js/Uint8Array. #js [0 1 2 3 255 16 32])
-        expected (backend-style-hash payload)]
+
+        ;; The expected value is derived on Core side
+        ;; by taking the payload and runnoing asset-data/safe-hash fn
+        expected "56ddd6a0a0f41e38faa52e20ea07c7c511ff8283"]
     (is (= expected (io-util/derive-content-hash payload)))))


### PR DESCRIPTION
This PR addsthe check and based on `content-hash` we check if assets are changed or not. Only the changed assets are included in the push command. This is an optimization related to preparing to make asset command public in flex-cli. 
