### PR TITLE
Node fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/clojure:tools-deps-node
+      - image: cimg/clojure:1.11-node
     steps:
       - checkout
       - restore_cache:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- The CLI now requires Node.js version 18 or newer. [#113](https://github.com/sharetribe/flex-cli/pull/113)
 - Update shadow-cljs to 2.15.12.
   [#111](https://github.com/sharetribe/flex-cli/pull/111)
 

--- a/deps.edn
+++ b/deps.edn
@@ -9,6 +9,4 @@
   fipp {:mvn/version "0.6.18"}
   aysylu/loom {:mvn/version "1.0.2"}
   thheller/shadow-cljs {:mvn/version "2.15.12"}
-
-  ;; Requires xmlhttprequest from NPM
-  cljs-ajax {:mvn/version "0.7.5"}}}
+  com.cognitect/transit-cljs {:mvn/version "0.8.280"}}}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "inquirer": "^6.2.2",
     "mkdirp": "^0.5.1",
     "open": "6.4.0",
-    "rimraf": "^3.0.0",
-    "xmlhttprequest": "^1.8.0"
+    "rimraf": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "form-data": "^2.5.1",
     "inquirer": "^6.2.2",
     "mkdirp": "^0.5.1",
     "open": "6.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/sharetribe/flex-cli"
   },
+  "engines": {
+    "node": ">=18"
+  },
   "bin": {
     "flex-cli": "target/min.js"
   },

--- a/src/sharetribe/flex_cli/api/client.cljs
+++ b/src/sharetribe/flex_cli/api/client.cljs
@@ -1,5 +1,5 @@
 (ns sharetribe.flex-cli.api.client
-  (:require [ajax.core :as ajax]
+  (:require [cognitect.transit :as t]
             [clojure.core.async :as async :refer [put! chan <! go]]
             [chalk]
             [goog.object]
@@ -99,67 +99,95 @@
   [ex-data]
   (-> ex-data :res :response :errors first))
 
+(def transit-reader (t/reader :json))
+(def transit-writer (t/writer :json))
+
+(defn- to-query-param [v]
+  (clj->js v))
+
+(defn- construct-url [url query-params]
+  (let [url (js/URL. url)]
+    (doseq [[k v] query-params]
+      (.set (.-searchParams url) (name k) (to-query-param v)))
+    url))
+
+(defn read-transit [s]
+  (try
+    {:success true
+     :data (t/read transit-reader s)}
+    (catch js/Error _e
+      {:success false})))
+
+(defn- handle-response [out-chan response req]
+  (->
+   (.text response)
+   (.then
+    (fn [body-str]
+      (let [parsed (read-transit body-str)]
+        (put! out-chan
+              (if (.-ok response)
+                (:data parsed)
+                (let [parsed (read-transit body-str)]
+                  (handle-error req
+                                (cond-> {:status (.-status response)
+                                         :status-text (.-statusText response)}
+                                  (:success parsed) (assoc :response (:data parsed))
+                                  (not (:success parsed)) (assoc :original-text body-str)))))))))))
+
 (defn do-get [client path query]
   (let [c (chan)]
-    (ajax/ajax-request
-     {:uri (str (config/value :api-base-url) path)
-      :method :get
-      :params query
-      :headers {"Authorization" (str "Apikey " (::api-key client))
-                "User-Agent" user-agent}
-      :handler (fn [[ok? response]]
-                 (put! c
-                       (if ok?
-                         response
-                         (handle-error {:client client
-                                        :path path
-                                        :query query}
-                                       response))))
-      :format (ajax/transit-request-format)
-      :response-format (ajax/transit-response-format)})
+    (-> (js/fetch
+         (construct-url (str (config/value :api-base-url) path) query)
+         (clj->js
+          {:method "GET"
+           :headers {"Authorization" (str "Apikey " (::api-key client))
+                     "User-Agent" user-agent
+                     "Accept" "application/transit+json"}}))
+        (.then (fn [response]
+                 (handle-response c response {:client client
+                                              :path path
+                                              :query query})))
+        ;; Unknown failure
+        (.catch (fn [error] (put! c (exception/exception :client/api-request-failed error)))))
     c))
 
 (defn do-post [client path query body]
   (let [c (chan)]
-    (ajax/ajax-request
-     {:uri (str (config/value :api-base-url) path)
-      :method :post
-      :url-params query
-      :params body
-      :headers {"Authorization" (str "Apikey " (::api-key client))
-                "User-Agent" user-agent}
-      :handler (fn [[ok? response]]
-                 (put! c
-                       (if ok?
-                         response
-                         (handle-error {:client client
-                                        :path path
-                                        :query query}
-                                       response))))
-      :format (ajax/transit-request-format)
-      :response-format (ajax/transit-response-format)})
+    (-> (js/fetch
+         (construct-url (str (config/value :api-base-url) path) query)
+         (clj->js
+          {:method "POST"
+           :body (t/write transit-writer body)
+           :headers {"Authorization" (str "Apikey " (::api-key client))
+                     "Content-Type" "application/transit+json"
+                     "User-Agent" user-agent
+                     "Accept" "application/transit+json"}}))
+        (.then (fn [response]
+                 (handle-response c response {:client client
+                                              :path path
+                                              :query query})))
+
+        ;; Unknown failure
+        (.catch (fn [error] (put! c (exception/exception :client/api-request-failed error)))))
     c))
 
-(defn do-multipart-post [client path query ^js form-data]
+(defn do-multipart-post [client path query form-data]
   (let [c (chan)]
-    (ajax/ajax-request
-     {:uri (str (config/value :api-base-url) path)
-      :method :post
-      :url-params query
-      :params form-data
-      :headers {"Authorization" (str "Apikey " (::api-key client))
-                "User-Agent" user-agent}
-      :handler (fn [[ok? response]]
-                 (put! c
-                       (if ok?
-                         response
-                         (handle-error {:client client
-                                        :path path
-                                        :query query}
-                                       response))))
-      :format {:write (fn [^js form-data] (.getBuffer form-data))
-               :content-type (goog.object/get (.getHeaders form-data) "content-type")}
-      :response-format (ajax/transit-response-format)})
+    (-> (js/fetch
+         (construct-url (str (config/value :api-base-url) path) query)
+         (clj->js
+          {:method "POST"
+           :body form-data
+           :headers {"Authorization" (str "Apikey " (::api-key client))
+                     "User-Agent" user-agent
+                     "Accept" "application/transit+json"}}))
+        (.then (fn [response]
+                 (handle-response c response {:client client
+                                              :path path
+                                              :query query})))
+
+        ;; Unknown failure
+        (.catch (fn [error] (put! c (exception/exception :client/api-request-failed error)))))
     c))
 
 (defn new-client [api-key]

--- a/src/sharetribe/flex_cli/commands/assets.cljs
+++ b/src/sharetribe/flex_cli/commands/assets.cljs
@@ -4,7 +4,6 @@
             [clojure.set :as set]
             [clojure.string :as str]
             [chalk]
-            [form-data :as FormData]
             [sharetribe.flex-cli.api.client :as api.client :refer [do-multipart-post do-get]]
             [sharetribe.flex-cli.async-util :refer [<? go-try]]
             [sharetribe.flex-cli.exception :as exception]
@@ -99,10 +98,10 @@
                         (.append form-data (str "staging-id-" i) (str staging-id)))
                       (when (and (not staging-id) data-raw)
                         (let [fname (or filename path)]
-                          (.append form-data (str "data-raw-" i) data-raw fname)))
+                          (.append form-data (str "data-raw-" i) (js/Blob. (array data-raw)) fname)))
                       form-data))
        :i (inc i)})
-    {:form-data (doto (FormData.)
+    {:form-data (doto (js/FormData.)
                   (.append "current-version" current-version))
      :i 0}
     assets)))

--- a/src/sharetribe/flex_cli/commands/assets.cljs
+++ b/src/sharetribe/flex_cli/commands/assets.cljs
@@ -64,7 +64,7 @@
        (exception/throw! :assets/stage-api-call-failed
                          {:asset-path path}))
 
-     (let [form-data (doto (FormData.)
+     (let [form-data (doto (js/FormData.)
                        (.append "file" data-raw file-name))]
        (try
          (let [res (<? (do-multipart-post api-client "/assets/stage"

--- a/src/sharetribe/flex_cli/process_util.cljs
+++ b/src/sharetribe/flex_cli/process_util.cljs
@@ -1,7 +1,6 @@
 (ns sharetribe.flex-cli.process-util
   (:require [clojure.set :as set]
             [chalk]
-            [form-data :as FormData]
             [sharetribe.flex-cli.io-util :as io-util]
             [sharetribe.flex-cli.api.client :as api.client]
             [sharetribe.flex-cli.exception :as exception]))
@@ -95,7 +94,7 @@
      (doto form-data
        (.append (str "template-html-" (clojure.core/name (:name tmpl))) (:html tmpl))
        (.append (str "template-subject-" (clojure.core/name (:name tmpl))) (:subject tmpl))))
-   (doto (FormData.)
+   (doto (js/FormData.)
      (.append "name" name)
      (.append "definition" definition))
    templates))


### PR DESCRIPTION
Use native FormData and Node's Fetch instead of `cljs-ajax`.

Since Node version 18, FormData has been natively supported. Also, Node 18 introduced Fetch which we can use to go HTTP instead of `cljs-ajax` library. In addition, `cljs-ajax` didn't see to have good support for binaries, which is needed for asset pulling with CLI.

Due to this PR, we now require Node version 18 or later. Node 18 was released Apr 19, 2022.