### PR TITLE
Use staging endpoint for image assets

### DIFF
--- a/src/sharetribe/flex_cli/commands/assets.cljs
+++ b/src/sharetribe/flex_cli/commands/assets.cljs
@@ -55,11 +55,36 @@
   (when-not (io-util/dir? path)
     (io-util/mkdirp path)))
 
+(defn- stage-asset
+  [params ctx]
+  (go-try
+   (let [{:keys [api-client marketplace]} ctx
+         {:keys [filename path data-raw] :as asset} params
+         file-name (or filename path)]
+     (when-not data-raw
+       (exception/throw! :assets/stage-api-call-failed
+                         {:asset-path path}))
+
+     (let [form-data (doto (FormData.)
+                       (.append "file" data-raw file-name))]
+       (try
+         (let [res (<? (do-multipart-post api-client "/assets/stage"
+                                          {:marketplace marketplace}
+                                          form-data))
+               staging-id (-> res :data :staging-id)]
+           (assoc asset :staging-id staging-id))
+         (catch js/Error e
+           (if (= :api/error (exception/type e))
+             (throw (exception/exception :assets/stage-api-call-failed
+                                         {:asset-path path
+                                          :api-error-data (exception/data e)}))
+             (throw e))))))))
+
 (defn- to-multipart-form-data
   [{:keys [current-version assets]}]
   (:form-data
    (reduce
-    (fn [{:keys [form-data i]} {:keys [path op data-raw filename]}]
+    (fn [{:keys [form-data i]} {:keys [path op data-raw filename staging-id]}]
       {:form-data (case op
                     :delete
                     (doto form-data
@@ -67,10 +92,15 @@
                       (.append (str "op-" i) "delete"))
 
                     (:upsert nil)
-                    (doto form-data
-                      (.append (str "path-" i) path)
-                      (.append (str "op-" i) "upsert")
-                      (.append (str "data-raw-" i) data-raw filename)))
+                    (let [form-data (doto form-data
+                                      (.append (str "path-" i) path)
+                                      (.append (str "op-" i) "upsert"))]
+                      (when staging-id
+                        (.append form-data (str "staging-id-" i) (str staging-id)))
+                      (when (and (not staging-id) data-raw)
+                        (let [fname (or filename path)]
+                          (.append form-data (str "data-raw-" i) data-raw fname)))
+                      form-data))
        :i (inc i)})
     {:form-data (doto (FormData.)
                   (.append "current-version" current-version))
@@ -163,7 +193,11 @@
 
          {:keys [version assets] :as asset-meta} (io-util/read-asset-meta path)
          local-assets (io-util/read-assets path)
-         changed-assets (filter-assets-to-upload assets local-assets)
+         changed-assets (into [] (filter-assets-to-upload assets local-assets))
+         json-asset? (fn [{:keys [path]}]
+                       (let [path-lower (str/lower-case path)]
+                         (str/ends-with? path-lower ".json")))
+         stageable-assets (into [] (remove json-asset? changed-assets))
 
          _ (validate-assets! local-assets)
 
@@ -183,9 +217,32 @@
      (if no-ops?
        (io-util/ppd [:span "Assets are up to date."])
        (let [query-params {:marketplace marketplace}
+             _ (when (seq stageable-assets)
+                 (io-util/log (.green chalk (str "Staging assets: "
+                                                 (str/join ", " (map :path stageable-assets))))))
+             staged-assets (when (seq stageable-assets)
+                             (loop [acc []
+                                    remaining stageable-assets]
+                               (if-let [asset (first remaining)]
+                                 (let [staged (<? (stage-asset asset ctx))]
+                                   (recur (conj acc staged) (rest remaining)))
+                                 acc)))
+             staged-by-path (into {} (map (juxt :path :staging-id)) (or staged-assets []))
+             upsert-ops (into []
+                              (map (fn [asset]
+                                     (let [path (:path asset)
+                                           staging-id (get staged-by-path path)]
+                                       (cond-> {:path path
+                                                :op :upsert}
+                                         staging-id (assoc :staging-id staging-id)
+                                         (and (not staging-id) (:data-raw asset))
+                                         (assoc :data-raw (:data-raw asset)
+                                                :filename (:filename asset)
+                                                :full-path (:full-path asset))))))
+                              changed-assets)
              body-params (to-multipart-form-data
                           {:current-version (if version version "nil") ;; stringify nil as initial version
-                           :assets (concat changed-assets delete-assets)})
+                           :assets (concat upsert-ops (or delete-assets []))})
 
              res (try
                    (<? (do-multipart-post api-client "/assets/push" query-params body-params))
@@ -204,6 +261,27 @@
                            " successfully created."]))
            (io-util/ppd [:span
                          "Assets are up to date."])))))))
+
+(defmethod exception/format-exception :assets/stage-api-call-failed [_ _ {:keys [asset-path api-error-data]}]
+  (let [error (when api-error-data (api.client/api-error api-error-data))
+        detail (or (:detail error) (:message error))
+        suggestion "Fix the file and rerun assets push to retry staging."
+        bold-path (.bold chalk (or asset-path "<unknown>"))]
+    (if (= :asset-invalid-content (:code error))
+      [:span
+       (.bold.red chalk "Failed to stage image ") bold-path ": "
+       (or detail "The file is missing or uses an unsupported format.")
+       :line suggestion]
+      (let [fallback (cond
+                       api-error-data (api.client/default-error-format api-error-data)
+                       :else [:span "Staging failed due to an unexpected error."])
+            fallback-span (if (and (vector? fallback) (= :span (first fallback)))
+                            fallback
+                            [:span fallback])]
+        (into (vec fallback-span)
+              [:line
+               "While staging image " bold-path "."
+               :line suggestion])))))
 
 (comment
 

--- a/src/sharetribe/flex_cli/io_util.cljs
+++ b/src/sharetribe/flex_cli/io_util.cljs
@@ -231,6 +231,7 @@
            (comp
             (remove #(= asset-meta-dirname %))
             (remove #(= ".git" %))
+            (remove #(= ".DS_Store" %))
             (mapcat (fn [dir-or-file]
                       (let [full-path (join path dir-or-file)]
                         (if (dir? full-path)


### PR DESCRIPTION
Implement CLI changes to stage asset files before pushing. Currently, our stage API endpoint supports staging only image files. On the CLI side, we skip staging for .json files; for all other asset types, we rely on the API to return an error if the file type is not supported.

(Internal use)