### PR TITLE
Ensure that file is Blob and not Buffer when using staging endpoint

### DIFF
--- a/src/sharetribe/flex_cli/commands/assets.cljs
+++ b/src/sharetribe/flex_cli/commands/assets.cljs
@@ -65,7 +65,7 @@
                          {:asset-path path}))
 
      (let [form-data (doto (js/FormData.)
-                       (.append "file" data-raw file-name))]
+                       (.append "file" (js/Blob. (array data-raw)) file-name))]
        (try
          (let [res (<? (do-multipart-post api-client "/assets/stage"
                                           {:marketplace marketplace}


### PR DESCRIPTION
There was an issue with pushing assets. When the assets contained files other than JSON, an error occurred during the staging step.

The staging call was appending a raw Buffer to FormData, but Node’s FormData expects a Blob for file uploads. Previously, we used the form-data library, which supported both Buffer and Blob. The error originated from the staging path, even though the subsequent push still succeeded because it uploads the raw data directly.

This PR fixes both issues:
- Stage now wraps data-raw in a Blob before calling FormData.append.
- Push now uses the staged ops instead of just the changed assets.